### PR TITLE
refactor(graph): tighten Edge, TreeStore logging, drop dead DAO method

### DIFF
--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/Edge.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/Edge.kt
@@ -2,7 +2,6 @@ package proj.memorchess.axl.core.graph
 
 import kotlin.time.Instant
 import proj.memorchess.axl.core.data.PositionKey
-import proj.memorchess.axl.core.date.DateUtil
 
 /**
  * Immutable edge in the [OpeningTree].
@@ -10,6 +9,10 @@ import proj.memorchess.axl.core.date.DateUtil
  * An edge represents a single move from [from] to [to]. The same logical edge is referenced by both
  * the origin node's outgoing map and the destination node's incoming map; both references hold the
  * same [Edge] instance after any mutation routed through [TreeStore].
+ *
+ * [updatedAt] is intentionally required from every caller so that two Edges built at different
+ * moments do not silently compare unequal because of a hidden clock read. [TreeStore] stamps it
+ * when the edge is created or loaded from disk; tests supply a fixed instant.
  *
  * @property from Position the move is played from.
  * @property move Move in standard algebraic notation.
@@ -24,7 +27,7 @@ data class Edge(
   val from: PositionKey,
   val move: String,
   val to: PositionKey,
-  val isGood: Boolean? = null,
-  val updatedAt: Instant = DateUtil.now(),
+  val isGood: Boolean?,
+  val updatedAt: Instant,
   val isDeleted: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -102,11 +102,18 @@ class TreeStore(private val database: DatabaseQueryManager) {
   }
 
   /**
-   * Stores [cardState] on the node at [positionKey] and persists it. The node must already exist in
-   * the cache, otherwise this is a no op.
+   * Stores [cardState] on the node at [positionKey] and persists it.
+   *
+   * Logs a warning and skips the write when [positionKey] is not in the cache; that should only
+   * happen if the position was deleted between the scheduler reading it and writing the result
+   * back.
    */
   suspend fun updateCardState(positionKey: PositionKey, cardState: CardState) {
-    val existing = tree.get(positionKey) ?: return
+    val existing = tree.get(positionKey)
+    if (existing == null) {
+      LOGGER.w { "Skipping card state update for unknown position $positionKey" }
+      return
+    }
     tree.put(existing.copy(cardState = cardState))
     persistNode(positionKey)
   }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestNavigationHistory.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestNavigationHistory.kt
@@ -4,15 +4,19 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.Instant
 import proj.memorchess.axl.core.data.PositionKey
 
 class TestNavigationHistory {
 
+  private val instant = Instant.parse("2026-01-01T00:00:00Z")
   private val startPos = PositionKey("start w K")
   private val posA = PositionKey("posA b K")
   private val posB = PositionKey("posB w K")
-  private val moveToA = Edge(from = startPos, move = "e4", to = posA)
-  private val moveToB = Edge(from = posA, move = "e5", to = posB)
+  private val moveToA =
+    Edge(from = startPos, move = "e4", to = posA, isGood = true, updatedAt = instant)
+  private val moveToB =
+    Edge(from = posA, move = "e5", to = posB, isGood = true, updatedAt = instant)
 
   @Test
   fun pushThenBackReturnsOriginalPosition() {
@@ -55,7 +59,7 @@ class TestNavigationHistory {
     nav.back()
     // Push a different move — should clear forward stack
     val posC = PositionKey("posC b K")
-    val moveToC = Edge(from = startPos, move = "d4", to = posC)
+    val moveToC = Edge(from = startPos, move = "d4", to = posC, isGood = true, updatedAt = instant)
     nav.push(moveToC, posC)
     assertNull(nav.forward())
   }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestOpeningTree.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestOpeningTree.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.scheduling.CardStateFactory
 import proj.memorchess.axl.test_util.TestDatabaseQueryManager
 
 /** Behavioural tests for the in memory graph, driven through [TreeStore]. */
@@ -93,5 +94,13 @@ class TestOpeningTree {
     store.eraseAll()
     assertNull(store.current().get(posA))
     assertNull(store.current().get(posB))
+  }
+
+  @Test
+  fun updateCardStateOnUnknownPositionIsANoOp() = runTest {
+    val store = TreeStore(TestDatabaseQueryManager.empty())
+    // posA is not in the tree. The call should log a warning and return without throwing.
+    store.updateCardState(posA, CardStateFactory.new())
+    assertNull(store.current().get(posA))
   }
 }

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
@@ -117,7 +117,5 @@ interface NodeEntityDao {
 
   @Query("SELECT MAX(updatedAt) FROM NodeEntity") suspend fun getLastNodeUpdate(): Instant?
 
-  @Query("SELECT * FROM NodeEntity") suspend fun getPositions(): List<NodeEntity>
-
   @Query("SELECT MAX(updatedAt) FROM MoveEntity") suspend fun getLastMoveUpdate(): Instant?
 }


### PR DESCRIPTION
## Summary

Three review notes from PR #136 addressed in one follow up.

## Changes

### `Edge.updatedAt` is now required

The previous `updatedAt: Instant = DateUtil.now()` default meant two structurally identical Edges built at different moments were not `equals`, because the default ran at construction time. Removed the default. Every call site stamps the value explicitly:
- `TreeStore.addMove` already did.
- `TreeStore.toEdge` (the persistence loader) already did.
- `TestNavigationHistory` now uses a fixed `Instant.parse(\"2026-01-01T00:00:00Z\")`.

### `TreeStore.updateCardState` warns on missing node

The previous silent `?: return` swallowed scheduler writes when a position was deleted between read and grade. Replaced with a warning log so the situation is observable without crashing the user.

### `NodeEntityDao.getPositions()` removed

The `SELECT * FROM NodeEntity` query had no callers after the Wave C graph rewrite. Dropped.

## Out of scope

A fourth review note proposed making `TreeStore.addMove` return `Unit`. Audit during implementation showed `LinesExplorer.playMove` consumes the returned `Edge` to push it onto `NavigationHistory`, so the return type stays as `Edge`.

## Test plan

- [x] `./gradlew ktfmtFormat`
- [x] `./gradlew compileKotlinJvm compileKotlinWasmJs compileTestKotlinJvm`
- [x] `./gradlew jvmTest` (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)