### PR TITLE
build: upgrade dependencies

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
   jvm()
 
   // iOS configuration
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeApp"
       isStatic = true
@@ -52,12 +52,9 @@ kotlin {
         outputFileName = "composeApp.js"
         devServer =
           (devServer ?: KotlinWebpackConfig.DevServer()).apply {
-            static =
-              (static ?: mutableListOf()).apply {
-                // Serve sources to debug inside browser
-                add(project.rootDir.path)
-                add(project.projectDir.path)
-              }
+            // Serve sources to debug inside browser
+            static(project.rootDir.path)
+            static(project.projectDir.path)
           }
       }
       testTask { useKarma { useFirefoxHeadless() } }
@@ -85,12 +82,12 @@ kotlin {
   sourceSets {
     commonMain.dependencies {
       // Compose dependencies
-      implementation(compose.runtime)
-      implementation(compose.foundation)
-      implementation(compose.material3)
-      implementation(compose.ui)
-      implementation(compose.components.resources)
-      implementation(compose.components.uiToolingPreview)
+      implementation(libs.compose.runtime)
+      implementation(libs.compose.foundation)
+      implementation(libs.compose.material3)
+      implementation(libs.compose.ui)
+      implementation(libs.compose.components.resources)
+      implementation(libs.compose.components.ui.tooling.preview)
 
       // Lifecycle dependencies
       implementation(libs.androidx.lifecycle.viewmodel)
@@ -142,7 +139,7 @@ kotlin {
     }
 
     androidMain.dependencies {
-      implementation(compose.preview)
+      implementation(libs.compose.ui.tooling.preview)
       implementation(libs.androidx.activity.compose)
       implementation(libs.androidx.material3.android)
     }
@@ -156,7 +153,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(libs.kotlin.test)
-      @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) implementation(compose.uiTest)
+      implementation(libs.compose.ui.test)
       implementation(libs.kotest.assertions)
     }
 
@@ -216,7 +213,6 @@ dependencies {
   // KSP processors for Room on different platforms
   add("kspAndroid", libs.androidx.room.compiler)
   add("kspIosSimulatorArm64", libs.androidx.room.compiler)
-  add("kspIosX64", libs.androidx.room.compiler)
   add("kspIosArm64", libs.androidx.room.compiler)
   add("kspJvm", libs.androidx.room.compiler)
 

--- a/composeApp/pre-compile.gradle.kts
+++ b/composeApp/pre-compile.gradle.kts
@@ -1,96 +1,94 @@
 import java.util.Properties
 
 // Task to generate Secrets.kt file
-val generateSecretsTask by
-  tasks.registering {
-    group = "codegen"
-    description = "Generate secrets from local.properties"
+val generateSecretsTask by tasks.registering {
+  group = "codegen"
+  description = "Generate secrets from local.properties"
 
-    val projectDirValue = projectDir
-    val rootProjectDirValue = rootProject.projectDir
+  val projectDirValue = projectDir
+  val rootProjectDirValue = rootProject.projectDir
 
-    // Determine which local.properties file to use
-    val moduleProps = File(projectDirValue, "local.properties")
-    val globalProps = File(rootProjectDirValue, "local.properties")
-    val propsFile =
-      when {
-        moduleProps.exists() -> moduleProps
-        globalProps.exists() -> globalProps
-        else -> null
-      }
-
-    // If no local.properties file is found, properties will be empty
-    val properties =
-      if (propsFile == null) {
-        Properties()
-      } else {
-        if (!propsFile.exists()) {
-          error("local.properties file not found at ${propsFile.absolutePath}")
-        }
-        Properties().apply { load(propsFile.inputStream()) }
-      }
-
-    // Create target directory and file
-    val (secretsPackageDir, secretsFile) = getGeneratedFileName(projectDirValue)
-
-    if (!secretsPackageDir.exists()) {
-      secretsPackageDir.mkdirs()
+  // Determine which local.properties file to use
+  val moduleProps = File(projectDirValue, "local.properties")
+  val globalProps = File(rootProjectDirValue, "local.properties")
+  val propsFile =
+    when {
+      moduleProps.exists() -> moduleProps
+      globalProps.exists() -> globalProps
+      else -> null
     }
 
-    // Generate Secrets.kt content
-    val content = buildString {
-      appendLine("package proj.memorchess.axl.core.config.generated")
-      appendLine()
-      appendLine("import proj.memorchess.axl.core.config.SecretsTemplate")
-      appendLine()
-      appendLine("/**")
-      appendLine(" * Contains secrets stored in local.properties.")
-      appendLine(" *")
-      appendLine(" * Automatically generated file. DO NOT EDIT!")
-      appendLine(" */")
-      appendLine("@Suppress(\"unused\")")
-      appendLine("object Secrets : SecretsTemplate() {")
-
-      properties.forEach { (key, value) ->
-        val originalKey = key.toString()
-        val camelCaseKey = originalKey.toCamelCase()
-
-        // Validate that the camelCase key is a valid Kotlin identifier
-        if (Regex("^[a-zA-Z_][a-zA-Z0-9_]*$").matches(camelCaseKey)) {
-          appendLine("    val $camelCaseKey = \"$value\"")
-        }
+  // If no local.properties file is found, properties will be empty
+  val properties =
+    if (propsFile == null) {
+      Properties()
+    } else {
+      if (!propsFile.exists()) {
+        error("local.properties file not found at ${propsFile.absolutePath}")
       }
-
-      appendLine("}")
+      Properties().apply { load(propsFile.inputStream()) }
     }
 
-    secretsFile.writeText(content)
+  // Create target directory and file
+  val (secretsPackageDir, secretsFile) = getGeneratedFileName(projectDirValue)
 
-    // Add Secrets.kt to .gitignore
-    addToGitIgnore(projectDirValue, secretsFile)
+  if (!secretsPackageDir.exists()) {
+    secretsPackageDir.mkdirs()
   }
+
+  // Generate Secrets.kt content
+  val content = buildString {
+    appendLine("package proj.memorchess.axl.core.config.generated")
+    appendLine()
+    appendLine("import proj.memorchess.axl.core.config.SecretsTemplate")
+    appendLine()
+    appendLine("/**")
+    appendLine(" * Contains secrets stored in local.properties.")
+    appendLine(" *")
+    appendLine(" * Automatically generated file. DO NOT EDIT!")
+    appendLine(" */")
+    appendLine("@Suppress(\"unused\")")
+    appendLine("object Secrets : SecretsTemplate() {")
+
+    properties.forEach { (key, value) ->
+      val originalKey = key.toString()
+      val camelCaseKey = originalKey.toCamelCase()
+
+      // Validate that the camelCase key is a valid Kotlin identifier
+      if (Regex("^[a-zA-Z_][a-zA-Z0-9_]*$").matches(camelCaseKey)) {
+        appendLine("    val $camelCaseKey = \"$value\"")
+      }
+    }
+
+    appendLine("}")
+  }
+
+  secretsFile.writeText(content)
+
+  // Add Secrets.kt to .gitignore
+  addToGitIgnore(projectDirValue, secretsFile)
+}
 
 // Task to clean Secrets.kt file
-val cleanSecretsTask by
-  tasks.registering {
-    group = "codegen"
-    description = "Clean generated Secrets.kt file"
-    val projectDirValue = projectDir
-    val (secretsPackageDir, secretsFile) = getGeneratedFileName(projectDirValue)
+val cleanSecretsTask by tasks.registering {
+  group = "codegen"
+  description = "Clean generated Secrets.kt file"
+  val projectDirValue = projectDir
+  val (secretsPackageDir, secretsFile) = getGeneratedFileName(projectDirValue)
 
-    doLast {
-      if (secretsFile.exists()) {
-        secretsFile.delete()
-        logger.info("🧹 Deleted generated Secrets.kt file")
-      }
+  doLast {
+    if (secretsFile.exists()) {
+      secretsFile.delete()
+      logger.info("🧹 Deleted generated Secrets.kt file")
+    }
 
-      // Also remove the directory if it's empty and only contains generated files
-      if (secretsPackageDir.exists() && secretsPackageDir.listFiles()?.isEmpty() == true) {
-        secretsPackageDir.delete()
-        logger.info("🧹 Removed empty generated directory")
-      }
+    // Also remove the directory if it's empty and only contains generated files
+    if (secretsPackageDir.exists() && secretsPackageDir.listFiles()?.isEmpty() == true) {
+      secretsPackageDir.delete()
+      logger.info("🧹 Removed empty generated directory")
     }
   }
+}
 
 // Helper functions
 fun getGeneratedFileName(projectDir: File): Pair<File, File> {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/engine/evaluation/StockfishEvaluator.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/engine/evaluation/StockfishEvaluator.kt
@@ -44,16 +44,15 @@ class StockfishEvaluator(private val maxDepth: Int = DEFAULT_SEARCH_DEPTH) {
   val bestMove: StateFlow<BestMove?> = _bestMove.asStateFlow()
 
   init {
-    initJob =
-      scope.launch {
-        try {
-          engine = getStockfish()
-        } catch (e: Exception) {
-          Logger.w(tag = TAG, throwable = e) {
-            "Stockfish not available on this platform: ${e.message}"
-          }
+    initJob = scope.launch {
+      try {
+        engine = getStockfish()
+      } catch (e: Exception) {
+        Logger.w(tag = TAG, throwable = e) {
+          "Stockfish not available on this platform: ${e.message}"
         }
       }
+    }
   }
 
   /**
@@ -75,25 +74,24 @@ class StockfishEvaluator(private val maxDepth: Int = DEFAULT_SEARCH_DEPTH) {
     _currentDepth.value = null
     _bestMove.value = null
 
-    searchJob =
-      scope.launch {
-        try {
-          currentEngine.setPosition(fen = fen)
-          val depthArg = if (maxDepth == 0) null else maxDepth
-          val result =
-            currentEngine.search(depth = depthArg) { info ->
-              info.depth?.let { _currentDepth.value = it }
-              val score = info.score ?: return@search
-              _evaluation.value = toEvaluationScore(score, isBlackToMove)
-              if (info.pv.isNotEmpty()) {
-                _bestMove.value = BestMove.fromUci(info.pv.first())
-              }
+    searchJob = scope.launch {
+      try {
+        currentEngine.setPosition(fen = fen)
+        val depthArg = if (maxDepth == 0) null else maxDepth
+        val result =
+          currentEngine.search(depth = depthArg) { info ->
+            info.depth?.let { _currentDepth.value = it }
+            val score = info.score ?: return@search
+            _evaluation.value = toEvaluationScore(score, isBlackToMove)
+            if (info.pv.isNotEmpty()) {
+              _bestMove.value = BestMove.fromUci(info.pv.first())
             }
-          _bestMove.value = BestMove.fromUci(result.bestMove)
-        } catch (e: Exception) {
-          Logger.w(tag = TAG, throwable = e) { "Evaluation failed: ${e.message}" }
-        }
+          }
+        _bestMove.value = BestMove.fromUci(result.bestMove)
+      } catch (e: Exception) {
+        Logger.w(tag = TAG, throwable = e) { "Evaluation failed: ${e.message}" }
       }
+    }
   }
 
   /** Stops the engine and cancels the coroutine scope. */

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
@@ -35,24 +35,23 @@ object GraphSerializer {
     val sorted = liveNodes.sortedBy { it.positionKey.value }
     val indexByKey = buildMap { sorted.forEachIndexed { i, node -> put(node.positionKey, i + 1) } }
 
-    val nodeLines =
-      sorted.mapIndexed { i, node ->
-        val idx = i + 1
-        val card = node.cardState
-        listOf(
-            idx,
-            node.positionKey.value,
-            node.depth,
-            card.dueDate,
-            card.lastReview?.toString() ?: NULL_TOKEN,
-            card.stability,
-            card.difficulty,
-            card.reps,
-            card.lapses,
-            node.updatedAt,
-          )
-          .joinToString(TAB)
-      }
+    val nodeLines = sorted.mapIndexed { i, node ->
+      val idx = i + 1
+      val card = node.cardState
+      listOf(
+          idx,
+          node.positionKey.value,
+          node.depth,
+          card.dueDate,
+          card.lastReview?.toString() ?: NULL_TOKEN,
+          card.stability,
+          card.difficulty,
+          card.reps,
+          card.lapses,
+          node.updatedAt,
+        )
+        .joinToString(TAB)
+    }
 
     val edges = buildList {
       for (node in sorted) {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/layout/MainLayout.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/layout/MainLayout.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.window.core.layout.WindowSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 
 /**
  * Main layout for the application.
@@ -30,7 +29,9 @@ fun MainLayout(
 ) {
   val isWide by
     remember(windowSizeClass) {
-      derivedStateOf { windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED }
+      derivedStateOf {
+        windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+      }
     }
   Row {
     AnimatedVisibility(

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/ui/util/FileExporter.nonJs.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/ui/util/FileExporter.nonJs.kt
@@ -6,6 +6,6 @@ import io.github.vinceglb.filekit.writeString
 
 /** Exports [content] via a native save dialog. */
 actual suspend fun exportToFile(content: String, baseName: String, extension: String) {
-  val file = FileKit.openFileSaver(suggestedName = baseName, extension = extension)
+  val file = FileKit.openFileSaver(suggestedName = baseName, defaultExtension = extension)
   file?.writeString(content)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,19 +3,20 @@ agp = "8.13.2"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"
-androidx-activityCompose = "1.12.4"
-androidx-lifecycle = "2.9.6"
+androidx-activityCompose = "1.13.0"
+androidx-lifecycle = "2.10.0"
 androidx-room = "2.8.4"
-chess-core = "1.0.1"
+chess-core = "1.0.2"
 composeHotReload = "1.1.1"
-compose-multiplatform = "1.10.3"
-filekit = "0.13.0"
+compose-multiplatform = "1.11.0"
+compose-material3 = "1.9.0"
+filekit = "0.14.1"
 hotpreview = "0.2.0"
 indexeddb = "0.12.0"
 kermit = "2.1.0"
 kover = "0.9.8"
 koin = "4.2.1"
-ktfmt = "0.25.0"
+ktfmt = "0.26.0"
 kotlin = "2.3.21"
 ksp = "2.3.8"
 kotest = "6.1.11"
@@ -26,11 +27,11 @@ material3-adaptive = "1.2.0"
 material3Android = "1.4.0"
 multiplatform-settings = "1.3.0"
 navigationComposeVersion = "2.9.2"
-slf4jApi = "2.0.17"
-sonar = "7.2.3.7755"
+slf4jApi = "2.0.18"
+sonar = "7.3.0.8198"
 sqlite = "2.6.2"
 stockfish-multiplatform = "0.1.0-alpha.11"
-uiTestJunit4Android = "1.10.5"
+uiTestJunit4Android = "1.11.2"
 xfeather_z = "1.1.1"
 
 [libraries]
@@ -44,6 +45,16 @@ material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adapti
 material-icons = {module = "org.jetbrains.compose.material:material-icons-core", version.ref = "material-icons" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationComposeVersion" }
 xfeather_z = { module = "br.com.devsrsouza.compose.icons:feather", version.ref = "xfeather_z" }
+
+# --- Compose Multiplatform ---
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-multiplatform" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
+compose-components-ui-tooling-preview = { module = "org.jetbrains.compose.components:components-ui-tooling-preview", version.ref = "compose-multiplatform" }
 
 # --- AndroidX lifecycle ---
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
## Summary

- Bump dependencies: compose-multiplatform 1.10.3 → 1.11.0, kotlin androidx-lifecycle 2.9.6 → 2.10.0, androidx-activityCompose 1.12.4 → 1.13.0, chess-core 1.0.1 → 1.0.2, filekit 0.13.0 → 0.14.1, ktfmt 0.25.0 → 0.26.0, slf4j 2.0.17 → 2.0.18, sonar 7.2.3 → 7.3.0, ui-test-junit4-android 1.10.5 → 1.11.2.
- Drop `iosX64()` target and `kspIosX64` config. CMP 1.11.0 drops Apple x86_64 (Kotlin deprecation). Only iosArm64 + iosSimulatorArm64 remain.
- Migrate Compose dependency DSL (`compose.runtime` etc.) to direct artifact coordinates in version catalog. material3 pinned separately to 1.9.0 (CMP 1.11.0 internal pin).
- Replace deprecated webpack `static = mutableListOf().apply { add(...) }` with `static(path)` fn calls.
- Drop deprecated `@OptIn(ExperimentalComposeLibrary)` for `compose.uiTest`.
- Fix source-level deprecations: `WindowWidthSizeClass.EXPANDED` → `WindowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)`; FileKit `openFileSaver` `extension` arg → `defaultExtension`.

## Test plan

- [ ] `./gradlew ktfmtCheck`
- [ ] `./gradlew build`
- [ ] `./gradlew desktopTest`
- [ ] `./gradlew :composeApp:compileKotlinIosArm64` (verify iOS still compiles)
- [ ] `./gradlew :composeApp:wasmJsBrowserDevelopmentWebpack` (verify wasm still builds)
- [ ] Manual: run desktop app, verify side bar shows on wide window
- [ ] Manual: export a file, verify save dialog uses correct default extension