### PR TITLE
ci: fix auto-update workflow action reference

### DIFF
--- a/.github/workflows/auto_update_prs.yml
+++ b/.github/workflows/auto_update_prs.yml
@@ -21,7 +21,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Auto update pull request branches
-        uses: maruloop/autoupdate-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          pr_filter: "all"
+        uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_FILTER: "all"


### PR DESCRIPTION
## Summary
- Replace non-existent `maruloop/autoupdate-action@v1` with the maintained `docker://chinthakagodawita/autoupdate-action:v1`.
- Move `github_token` / `pr_filter` to the `env:` block (`GITHUB_TOKEN` / `PR_FILTER`), which is the interface this action exposes.
- Workflow was failing with `Unable to resolve action maruloop/autoupdate-action, not found`.

## Test plan
- [ ] Merge and confirm the next push to `master` triggers the workflow without the resolve error.
- [ ] Verify open PRs get auto-updated against `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)