### PR TITLE
ci: add iOS simulator test job in parallel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -315,12 +315,19 @@ jobs:
           retention-days: 1
 
   # Full tier: iOS simulator tests (no coverage - Kover does not support Kotlin/Native)
+  # Compose Multiplatform 1.11 / Kotlin 2.3.21 link against iOS 26 SDK symbols
+  # (e.g. UIViewLayoutRegion), so this needs Xcode 26 — macos-latest (Xcode 16.x)
+  # fails at link time. macos-26 ships Xcode 26; pin it explicitly for reproducibility.
   ios-tests:
     needs: [detect]
     if: needs.detect.outputs.tier == 'full'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0'
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -314,11 +314,42 @@ jobs:
           path: composeApp/build/test-results/wasmJsBrowserTest/*.xml
           retention-days: 1
 
+  # Full tier: iOS simulator tests (no coverage - Kover does not support Kotlin/Native)
+  ios-tests:
+    needs: [detect]
+    if: needs.detect.outputs.tier == 'full'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+
+      - name: Run iOS simulator tests
+        run: ./gradlew :composeApp:iosSimulatorArm64Test
+
+      - name: Upload iOS test result files
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ios-test-results
+          path: composeApp/build/test-results/iosSimulatorArm64Test/*.xml
+          retention-days: 1
+
   # Publish aggregated test results and badge
   publish-test-results:
     name: Publish Test Results
     runs-on: ubuntu-latest
-    needs: [detect, jvm-tests, android-tests, wasm-tests]
+    needs: [detect, jvm-tests, android-tests, wasm-tests, ios-tests]
     if: >
       always() && needs.detect.outputs.tier != 'noop' &&
       (needs.jvm-tests.result == 'success' || needs.jvm-tests.result == 'failure')
@@ -348,6 +379,13 @@ jobs:
         with:
           name: wasm-test-results
           path: test-results/wasm
+
+      - name: Download iOS test results
+        if: needs.detect.outputs.tier == 'full' && needs.ios-tests.result != 'skipped'
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-test-results
+          path: test-results/ios
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -442,7 +480,7 @@ jobs:
   check-status:
     name: All checks passed
     runs-on: ubuntu-latest
-    needs: [detect, format-check, jvm-tests, compile-multiplat, android-tests, wasm-tests, publish-test-results, sonar-analysis]
+    needs: [detect, format-check, jvm-tests, compile-multiplat, android-tests, wasm-tests, ios-tests, publish-test-results, sonar-analysis]
     if: always()
     steps:
       - name: Check job results
@@ -453,6 +491,7 @@ jobs:
           MULTIPLAT: ${{ needs.compile-multiplat.result }}
           ANDROID: ${{ needs.android-tests.result }}
           WASM: ${{ needs.wasm-tests.result }}
+          IOS: ${{ needs.ios-tests.result }}
           PUBLISH: ${{ needs.publish-test-results.result }}
           SONAR: ${{ needs.sonar-analysis.result }}
         run: |
@@ -477,6 +516,7 @@ jobs:
           if [ "$TIER" = "full" ]; then
             [ "$ANDROID" = "success" ] || fail android-tests "$ANDROID"
             [ "$WASM"    = "success" ] || fail wasm-tests "$WASM"
+            [ "$IOS"     = "success" ] || fail ios-tests "$IOS"
             [ "$SONAR"   = "success" ] || fail sonar-analysis "$SONAR"
           fi
 

--- a/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/auth/PkceGenerator.ios.kt
+++ b/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/auth/PkceGenerator.ios.kt
@@ -2,6 +2,7 @@ package proj.memorchess.axl.core.auth
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.readBytes

--- a/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/data/DataBase.ios.kt
+++ b/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/data/DataBase.ios.kt
@@ -2,6 +2,7 @@ package proj.memorchess.axl.core.data
 
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDomainMask
@@ -11,6 +12,7 @@ actual fun databaseBuilder(): RoomDatabase.Builder<CustomDatabase> {
   return Room.databaseBuilder<CustomDatabase>(name = dbFilePath)
 }
 
+@OptIn(ExperimentalForeignApi::class)
 private fun documentDirectory(): String {
   val documentDirectory =
     NSFileManager.defaultManager.URLForDirectory(

--- a/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/data/DataBase.ios.kt
+++ b/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/data/DataBase.ios.kt
@@ -1,10 +1,14 @@
 package proj.memorchess.axl.core.data
 
+import androidx.room.Room
 import androidx.room.RoomDatabase
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
 
 actual fun databaseBuilder(): RoomDatabase.Builder<CustomDatabase> {
   val dbFilePath = documentDirectory() + "/my_room.db"
-  return Room.databaseBuilder<AppDatabase>(name = dbFilePath)
+  return Room.databaseBuilder<CustomDatabase>(name = dbFilePath)
 }
 
 private fun documentDirectory(): String {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ navigationComposeVersion = "2.9.2"
 slf4jApi = "2.0.18"
 sonar = "7.3.0.8198"
 sqlite = "2.6.2"
-stockfish-multiplatform = "0.1.0-alpha.11"
+stockfish-multiplatform = "0.1.0-alpha.13"
 uiTestJunit4Android = "1.11.2"
 xfeather_z = "1.1.1"
 


### PR DESCRIPTION
## Summary

Closes #147.

Adds CI coverage for the Kotlin/Native iOS target, which until now was never compiled or tested in CI — iOS-only breakage was invisible until a local Mac build.

The `ios-tests` job was originally added and then reverted in #143 because `fr.axl-lvy:stockfish-multiplatform-iossimulatorarm64` was missing from `0.1.0-alpha.11` (the upstream publish workflow ran on Ubuntu, which silently dropped iOS klibs). That's now fixed upstream and `v0.1.0-alpha.13` ships the iOS klibs.

## Changes

- Bump `stockfish-multiplatform` `0.1.0-alpha.11` → `0.1.0-alpha.13` in `gradle/libs.versions.toml`. Verified the `iossimulatorarm64` klib resolves from GitHub Packages.
- Re-add the `ios-tests` job in `.github/workflows/check.yml`:
  - `macos-latest`, `full` tier only, parallel with `android-tests` / `wasm-tests`.
  - Runs `./gradlew :composeApp:iosSimulatorArm64Test`.
  - Uploads `ios-test-results`.
- Wire into `publish-test-results.needs` + its download step, and `check-status.needs` + the full-tier status gate (mirroring `wasm-tests`).

## Notes

iOS coverage in Sonar remains out of scope (Kover doesn't support Kotlin/Native); `iosMain` stays excluded from coverage but analyzed for quality. `iosSimulatorArm64Test` can only run on macOS, so the job's first real pass/fail shows on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)