### PR TITLE
fix(scheduling): persist CardPhase in export, real fuzz RNG, canonical lapse count

### DIFF
--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/Koin.kt
@@ -4,6 +4,7 @@ import com.russhwolf.settings.Settings
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
+import kotlin.random.Random
 import kotlinx.serialization.json.Json
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -21,6 +22,7 @@ import proj.memorchess.axl.core.data.explorer.ExplorerCache
 import proj.memorchess.axl.core.data.explorer.LichessExplorerClient
 import proj.memorchess.axl.core.data.explorer.getPlatformSpecificExplorerCache
 import proj.memorchess.axl.core.data.getPlatformSpecificLocalDatabase
+import proj.memorchess.axl.core.date.DateUtil
 import proj.memorchess.axl.core.graph.TrainingScheduler
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.core.scheduling.Fsrs6SchedulingAlgorithm
@@ -40,10 +42,16 @@ fun initKoinModules(): Array<Module> {
     single<Settings> { getPlatformSpecificSettings() }
   }
 
+  // One process-wide generator seeded from the wall clock at app start. A shared advancing RNG (not
+  // a per-card hash) is what lets cards graded identically on the same day scatter across their
+  // fuzz band instead of bunching on one due day.
+  val schedulingRandom = Random(DateUtil.now().toEpochMilliseconds())
+
   val schedulingModule = module {
     single<SchedulingAlgorithm> {
       Fsrs6SchedulingAlgorithm(
         enableFuzz = { FUZZ_ENABLED_SETTING.getValue() },
+        nextFuzz = { schedulingRandom.nextDouble() },
         enableShortTerm = { SHORT_TERM_ENABLED_SETTING.getValue() },
       )
     }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
@@ -4,6 +4,7 @@ import kotlin.time.Instant
 import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 
 /**
@@ -12,8 +13,9 @@ import proj.memorchess.axl.core.scheduling.CardState
  *
  * The format has two sections separated by a blank line:
  * - **Node lines**:
- *   `<index>\t<positionKey>\t<depth>\t<dueDate>\t<lastReview>\t<stability>\t<difficulty>\t<reps>\t<lapses>\t<updatedAt>`
- *   where `<lastReview>` is the literal string `null` for a card that has never been reviewed.
+ *   `<index>\t<positionKey>\t<depth>\t<dueDate>\t<lastReview>\t<stability>\t<difficulty>\t<reps>\t<lapses>\t<phase>\t<step>\t<updatedAt>`
+ *   where `<lastReview>` is the literal string `null` for a card that has never been reviewed and
+ *   `<phase>` is a [proj.memorchess.axl.core.scheduling.CardPhase] name.
  * - **Edge lines**: `<originIndex>\t<destIndex>\t<move>\t<isGood>\t<updatedAt>`
  *
  * Nodes are sorted by [PositionKey.value] and edges by `(originIndex, destIndex, move)` for
@@ -27,7 +29,7 @@ object GraphSerializer {
   private const val BAD = "-"
   private const val UNKNOWN = "?"
   private const val NULL_TOKEN = "null"
-  private const val NODE_FIELD_COUNT = 10
+  private const val NODE_FIELD_COUNT = 12
 
   /** Serializes nodes to a deterministic text string. Filters out deleted nodes and moves. */
   fun serialize(nodes: List<DataNode>): String {
@@ -48,6 +50,8 @@ object GraphSerializer {
           card.difficulty,
           card.reps,
           card.lapses,
+          card.phase.name,
+          card.step,
           node.updatedAt,
         )
         .joinToString(TAB)
@@ -121,6 +125,8 @@ object GraphSerializer {
             difficulty = parts[6].toDouble(),
             reps = parts[7].toInt(),
             lapses = parts[8].toInt(),
+            phase = runCatching { CardPhase.valueOf(parts[9]) }.getOrDefault(CardPhase.NEW),
+            step = parts[10].toInt(),
           )
         put(
           index,
@@ -128,7 +134,7 @@ object GraphSerializer {
             positionKey = PositionKey(parts[1]),
             depth = parts[2].toInt(),
             cardState = cardState,
-            updatedAt = Instant.parse(parts[9]),
+            updatedAt = Instant.parse(parts[11]),
           ),
         )
       }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/scheduling/Fsrs6SchedulingAlgorithm.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/scheduling/Fsrs6SchedulingAlgorithm.kt
@@ -7,6 +7,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.round
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
@@ -32,6 +33,12 @@ import kotlin.time.Instant
  *   interval fuzz is applied. Defaults to off, matching ts-fsrs' `default_enable_fuzz = false`. It
  *   is a supplier rather than a flat flag so a user toggling the setting takes effect immediately
  *   on the long lived singleton without a restart.
+ * @property nextFuzz Source of the per-review fuzz pick, a unit value in `[0, 1)` drawn once per
+ *   [schedule] call and shared across the four candidate grades so the spread is keyed on the
+ *   review event, not the grade. Defaults to a fresh draw from [Random.Default]; production seeds a
+ *   single process-wide [Random] from the wall clock at app start so that two cards graded
+ *   identically on the same day still scatter across their fuzz band. Tests inject a fixed-seed
+ *   [Random] for reproducibility.
  * @property enableShortTerm Supplier read on every [schedule] call deciding whether the short term
  *   (learning steps) scheduler runs. Defaults to on, matching ts-fsrs' `default_enable_short_term =
  *   true`. When off, every review graduates straight to a day grained [CardPhase.REVIEW] interval,
@@ -46,6 +53,7 @@ class Fsrs6SchedulingAlgorithm(
   private val requestRetention: Double = DEFAULT_REQUEST_RETENTION,
   private val maximumInterval: Int = DEFAULT_MAXIMUM_INTERVAL,
   private val enableFuzz: () -> Boolean = { false },
+  private val nextFuzz: () -> Double = { Random.Default.nextDouble() },
   private val enableShortTerm: () -> Boolean = { true },
   private val learningSteps: List<Duration> = DEFAULT_LEARNING_STEPS,
   private val relearningSteps: List<Duration> = DEFAULT_RELEARNING_STEPS,
@@ -118,9 +126,11 @@ class Fsrs6SchedulingAlgorithm(
       }
     val difficulty =
       if (lastReview == null) initDifficulty(grade) else nextDifficulty(base.difficulty, grade)
-    val fuzz = fuzzFactor(base.stability, base.difficulty, base.reps, elapsedDays)
+    val fuzz = nextFuzz()
     val outcome = route(base.phase, base.step, grade, stability, elapsedDays, fuzz)
-    val isLapse = grade == ReviewGrade.AGAIN
+    // A lapse is a forgotten *graduated* card, matching canonical FSRS. Failing during initial
+    // learning or while already relearning does not add another lapse.
+    val isLapse = grade == ReviewGrade.AGAIN && base.phase == CardPhase.REVIEW
     return CardState(
       dueDate = now + outcome.delay,
       lastReview = now,
@@ -203,7 +213,7 @@ class Fsrs6SchedulingAlgorithm(
   private fun firstReview(base: CardState, grade: ReviewGrade, now: Instant): CardState {
     val initialStabilities = ReviewGrade.entries.associateWith { initStability(it) }
     val initialDifficulties = ReviewGrade.entries.associateWith { initDifficulty(it) }
-    val fuzz = fuzzFactor(base.stability, base.difficulty, base.reps, elapsedDays = 0.0)
+    val fuzz = nextFuzz()
     val intervals =
       monotonicIntervals(
         initialStabilities.mapValues { (_, s) -> intervalDays(s, elapsedDays = 0.0, fuzz) }
@@ -234,7 +244,7 @@ class Fsrs6SchedulingAlgorithm(
           nextRecallStability(base.difficulty, base.stability, retrievability, candidate)
         }
       }
-    val fuzz = fuzzFactor(base.stability, base.difficulty, base.reps, elapsedDays)
+    val fuzz = nextFuzz()
     val intervals =
       monotonicIntervals(stabilities.mapValues { (_, s) -> intervalDays(s, elapsedDays, fuzz) })
     val difficulty = nextDifficulty(base.difficulty, grade)
@@ -365,40 +375,6 @@ class Fsrs6SchedulingAlgorithm(
     return floor(fuzz * (maxIvl - minIvl + 1.0) + minIvl).toLong().coerceAtLeast(1L)
   }
 
-  /**
-   * Deterministic unit value in `[0, 1)` derived purely from the pre review card state.
-   *
-   * FSRS keys its fuzz on the card identity (ts-fsrs seeds an `alea` PRNG from the card id and
-   * review count); the [SchedulingAlgorithm] interface deliberately does not expose the position
-   * key, so we seed from the card's own stability, difficulty, review count and elapsed days
-   * instead. This still satisfies the functional requirement — the same card recomputed yields the
-   * same fuzz — and de bunches cards once their review histories diverge. Two brand new cards
-   * graded identically on the same day will, however, receive the same fuzz; per position spreading
-   * would require threading the position key through [schedule].
-   */
-  private fun fuzzFactor(
-    stability: Double,
-    difficulty: Double,
-    reps: Int,
-    elapsedDays: Double,
-  ): Double {
-    var h = FUZZ_SEED_INIT
-    h = mix(h xor stability.toRawBits())
-    h = mix(h xor difficulty.toRawBits())
-    h = mix(h xor reps.toLong())
-    h = mix(h xor elapsedDays.toRawBits())
-    // Top 53 bits over 2^53 gives a uniform double in [0, 1).
-    return (h ushr 11).toDouble() / TWO_POW_53
-  }
-
-  /** SplitMix64 finalizing mix, used to turn the seed accumulator into a well spread hash. */
-  private fun mix(value: Long): Long {
-    var z = value
-    z = (z xor (z ushr 30)) * -0x40a7b892e31b1a47L
-    z = (z xor (z ushr 27)) * -0x6b2fb644ecceee15L
-    return z xor (z ushr 31)
-  }
-
   private fun Double.clamp(lo: Double, hi: Double): Double =
     if (this < lo) lo else if (this > hi) hi else this
 
@@ -458,12 +434,6 @@ class Fsrs6SchedulingAlgorithm(
         FuzzRange(start = 7.0, end = 20.0, factor = 0.1),
         FuzzRange(start = 20.0, end = Double.POSITIVE_INFINITY, factor = 0.05),
       )
-
-    /** Golden ratio derived odd constant seeding the [fuzzFactor] accumulator. */
-    private const val FUZZ_SEED_INIT: Long = -0x61c8864680b583ebL
-
-    /** `2.0^53`, the divisor turning a 53 bit hash into a uniform double in `[0, 1)`. */
-    private const val TWO_POW_53: Double = 9_007_199_254_740_992.0
 
     const val DEFAULT_REQUEST_RETENTION: Double = 0.9
     const val DEFAULT_MAXIMUM_INTERVAL: Int = 36500

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
@@ -8,6 +8,7 @@ import kotlin.time.Instant
 import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 
 class TestGraphSerializer {
@@ -262,6 +263,8 @@ class TestGraphSerializer {
 
   @Test
   fun cardStateAndDepthSurviveRoundTrip() {
+    // Non-default phase and step so the round trip would catch a dropped column: a card mid
+    // relearning must not silently reset to NEW/0 on export then import.
     val state =
       CardState(
         dueDate = instant3,
@@ -270,6 +273,8 @@ class TestGraphSerializer {
         difficulty = 6.25,
         reps = 4,
         lapses = 1,
+        phase = CardPhase.RELEARNING,
+        step = 1,
       )
     val node =
       DataNode(
@@ -285,6 +290,35 @@ class TestGraphSerializer {
     result[0].cardState shouldBe state
     result[0].depth shouldBe 7
     result[0].updatedAt shouldBe instant2
+  }
+
+  @Test
+  fun everyCardPhaseSurvivesRoundTrip() {
+    for (phase in CardPhase.entries) {
+      val state =
+        CardState(
+          dueDate = instant3,
+          lastReview = instant2,
+          stability = 1.0,
+          difficulty = 5.0,
+          reps = 1,
+          lapses = 0,
+          phase = phase,
+          step = 0,
+        )
+      val node =
+        DataNode(
+          positionKey = startPos,
+          previousAndNextMoves = PreviousAndNextMoves(),
+          cardState = state,
+          depth = 0,
+          updatedAt = instant2,
+        )
+
+      val result = GraphSerializer.deserialize(GraphSerializer.serialize(listOf(node)))
+
+      result[0].cardState.phase shouldBe phase
+    }
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestSingleMoveTrainer.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestSingleMoveTrainer.kt
@@ -15,6 +15,7 @@ import proj.memorchess.axl.core.engine.GameEngine
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.core.interactions.SingleMoveTrainer
+import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 import proj.memorchess.axl.test_util.TestWithKoin
 
@@ -48,6 +49,9 @@ class TestSingleMoveTrainer : TestWithKoin() {
         difficulty = 5.0,
         reps = 1,
         lapses = 0,
+        // A graduated card due for review: a wrong answer is a genuine lapse (REVIEW ->
+        // relearning).
+        phase = CardPhase.REVIEW,
       )
 
     testNode =

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/scheduling/TestFsrs6SchedulingAlgorithm.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/scheduling/TestFsrs6SchedulingAlgorithm.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -54,8 +55,11 @@ class TestFsrs6SchedulingAlgorithm {
   }
 
   @Test
-  fun firstReviewWithAgainCountsAsLapse() {
-    val state = algorithm.schedule(previous = null, grade = ReviewGrade.AGAIN, now = now)
+  fun firstReviewWithAgainCountsAsLapseInLongTermMode() {
+    // The long term path graduates the first review straight to REVIEW, so a fresh AGAIN there is a
+    // forgotten review and counts a lapse. The short term default instead opens learning and counts
+    // no lapse until a graduated card is forgotten — see newCardAgainStaysOnFirstStep.
+    val state = longTerm.schedule(previous = null, grade = ReviewGrade.AGAIN, now = now)
     state.lapses shouldBe 1
     state.reps shouldBe 1
   }
@@ -156,10 +160,12 @@ class TestFsrs6SchedulingAlgorithm {
     before.stability shouldBe atZero.stability
   }
 
-  private val fuzzy = Fsrs6SchedulingAlgorithm(enableFuzz = { true })
+  // Fuzz on with a constant midpoint pick, so the fuzzed interval is deterministic and exercises
+  // the fuzz path without depending on a particular RNG draw.
+  private val fuzzy = Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 })
 
   private val longTermFuzzy =
-    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, enableShortTerm = { false })
+    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 }, enableShortTerm = { false })
 
   /** EASY initial stability 8.2956 over FACTOR rounds to an 8 day interval with no fuzz applied. */
   @Test
@@ -168,12 +174,34 @@ class TestFsrs6SchedulingAlgorithm {
     (state.dueDate - now).inWholeDays shouldBe 8L
   }
 
-  /** Scheduling the same card twice yields the same fuzzed interval; the spread is reproducible. */
+  /**
+   * Two algorithms sharing the same RNG seed produce the same fuzzed interval: it is reproducible.
+   */
   @Test
-  fun fuzzIsDeterministicForTheSameCard() {
-    val a = fuzzy.schedule(previous = null, grade = ReviewGrade.EASY, now = now)
-    val b = fuzzy.schedule(previous = null, grade = ReviewGrade.EASY, now = now)
-    a.dueDate shouldBe b.dueDate
+  fun fuzzIsReproducibleUnderAFixedSeed() {
+    val a = Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = Random(42)::nextDouble)
+    val b = Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = Random(42)::nextDouble)
+    val stateA = a.schedule(previous = null, grade = ReviewGrade.EASY, now = now)
+    val stateB = b.schedule(previous = null, grade = ReviewGrade.EASY, now = now)
+    stateA.dueDate shouldBe stateB.dueDate
+  }
+
+  /**
+   * The whole point of fuzz: identical fresh cards graded the same way on the same day must not all
+   * land on one due day. Scheduling the same fresh EASY card repeatedly off a shared advancing RNG
+   * produces more than one distinct interval — the old per-card-state hash gave every fresh card
+   * the same value and so failed to de-bunch them.
+   */
+  @Test
+  fun fuzzSpreadsIdenticalFreshCardsAcrossDifferentDays() {
+    val rng = Random(1)
+    val algo = Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = rng::nextDouble)
+    val intervals =
+      (1..20).map {
+        (algo.schedule(previous = null, grade = ReviewGrade.EASY, now = now).dueDate - now)
+          .inWholeDays
+      }
+    intervals.toSet().size shouldBeGreaterThan 1
   }
 
   /**
@@ -228,14 +256,17 @@ class TestFsrs6SchedulingAlgorithm {
     (state.dueDate - now) shouldBe 10.minutes
   }
 
-  /** A new card answered AGAIN sits on the first learning step (one minute) and counts a lapse. */
+  /**
+   * A new card answered AGAIN sits on the first learning step (one minute). Failing during initial
+   * learning is not a lapse — canonical FSRS counts a lapse only for a forgotten graduated card.
+   */
   @Test
   fun newCardAgainStaysOnFirstStep() {
     val state = algorithm.schedule(previous = null, grade = ReviewGrade.AGAIN, now = now)
     state.phase shouldBe CardPhase.LEARNING
     state.step shouldBe 0
     (state.dueDate - now) shouldBe 1.minutes
-    state.lapses shouldBe 1
+    state.lapses shouldBe 0
   }
 
   /** EASY graduates a new card immediately to a day grained review interval. */
@@ -264,6 +295,17 @@ class TestFsrs6SchedulingAlgorithm {
     lapsed.step shouldBe 0
     (lapsed.dueDate - graduated.dueDate) shouldBe 10.minutes
     lapsed.lapses shouldBe 1
+  }
+
+  /** Failing again while already relearning does not add a second lapse. */
+  @Test
+  fun failingInRelearningDoesNotDoubleCountLapses() {
+    val graduated = algorithm.schedule(previous = null, grade = ReviewGrade.EASY, now = now)
+    val lapsed = algorithm.schedule(graduated, ReviewGrade.AGAIN, graduated.dueDate)
+    val stillRelearning = algorithm.schedule(lapsed, ReviewGrade.AGAIN, lapsed.dueDate)
+    lapsed.lapses shouldBe 1
+    stillRelearning.phase shouldBe CardPhase.RELEARNING
+    stillRelearning.lapses shouldBe 1
   }
 
   /** Passing the single relearning step returns a lapsed card to a day grained review interval. */


### PR DESCRIPTION
Follow-up fixes to the FSRS short-term scheduler / card state machine merged in #152, found during review.

## #1 — `GraphSerializer` dropped `phase`/`step` (functional bug)
Adding `phase`/`step` to `CardState` threaded them through the Room and IndexedDB mappers but missed the third `CardState` (de)serialization consumer, `GraphSerializer` (the export/import feature). Export→import reset **every** card to `CardPhase.NEW`/`step 0` — including mature `REVIEW` cards, which the short-term scheduler (on by default) then forced back through the `1m`/`10m` learning steps.

- Serialize `phase` + `step` (`NODE_FIELD_COUNT` 10→12), parse back with the same `runCatching { CardPhase.valueOf(...) }.getOrDefault(NEW)` guard the other mappers use, update the format KDoc.
- The existing `cardStateAndDepthSurviveRoundTrip` test passed only because it left `phase`/`step` at their defaults — strengthened it to non-default values and added an every-`CardPhase` round-trip case.

## #3 — fuzz now uses a real RNG
Fuzz was seeded from the pre-review card state, so a batch of brand-new cards (all `0,0,0,0`) hashed to the **same** value and still bunched on one due day — the exact spike fuzz exists to prevent.

- Replaced the state hash with an injected `nextFuzz: () -> Double` (one draw per review, shared across the four candidate grades).
- Koin wires it to a single process-wide `Random` seeded from the wall clock at app start; tests inject a fixed seed.
- Reworked the determinism test into a fixed-seed reproducibility test and added `fuzzSpreadsIdenticalFreshCardsAcrossDifferentDays` (the regression test for the actual goal).

## #2 — canonical lapse count
New-card `AGAIN` counted a lapse. Canonical FSRS counts a lapse only when a graduated `REVIEW` card is forgotten — gated `isLapse` on `base.phase == REVIEW`. Updated `newCardAgainStaysOnFirstStep` (now `lapses == 0`), added a no-double-count-in-relearning test, switched `firstReviewWithAgainCountsAsLapse` to the long-term variant (where it still legitimately counts), and fixed `TestSingleMoveTrainer`'s mis-modeled `NEW` card (it represents a graduated `REVIEW` card).

## Test plan
- `./gradlew :composeApp:jvmTest` — green.
- `./gradlew ktfmtCheck` — clean.
- `./gradlew compileKotlinWasmJs` — compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)