### PR TITLE
chore(deps): bump stockfish-multiplatform to 0.1.0-alpha.14

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ navigationComposeVersion = "2.9.2"
 slf4jApi = "2.0.18"
 sonar = "7.3.0.8198"
 sqlite = "2.6.2"
-stockfish-multiplatform = "0.1.0-alpha.13"
+stockfish-multiplatform = "0.1.0-alpha.14"
 uiTestJunit4Android = "1.11.2"
 xfeather_z = "1.1.1"
 


### PR DESCRIPTION
## Summary

Bumps `stockfish-multiplatform` from `0.1.0-alpha.13` to `0.1.0-alpha.14`.

This release fixes the close-during-search engine-lifetime race — a native use-after-free SIGSEGV (and, on some backends, a hang) when `close()` runs while a `search()` read loop is still active. That is the root cause of the Android emulator flake in `TestStockfishEvaluator.newEvaluationResetsPreviousResults`.

No app-side code change is needed — `StockfishEvaluator`'s existing `close()`-during-search path becomes memory-safe and no longer hangs.

- Library fix: Axl-Lvy/Stockfish-Multiplatform#9
- Library release: https://github.com/Axl-Lvy/Stockfish-Multiplatform/releases/tag/v0.1.0-alpha.14

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)