### PR TITLE
ci: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "semanticCommitType": "ci",
+      "groupName": "github actions"
+    },
+    {
+      "groupName": "kotlin",
+      "matchPackageNames": [
+        "org.jetbrains.kotlin:*",
+        "org.jetbrains.kotlin.*",
+        "com.google.devtools.ksp*"
+      ]
+    },
+    {
+      "groupName": "compose",
+      "matchPackageNames": ["org.jetbrains.compose*", "org.jetbrains.androidx.*"]
+    },
+    {
+      "groupName": "androidx",
+      "matchPackageNames": ["androidx.*", "com.android.*"]
+    },
+    {
+      "groupName": "ktor",
+      "matchPackageNames": ["io.ktor*"]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #163

Adds `renovate.json` for automated dependency updates:

- **Schedule**: weekly, Monday before 6am (Europe/Paris), `prConcurrentLimit: 5`. Every `libs.versions.toml` change triggers the full CI tier (Android emulator shards + iOS simulator), so PRs are bounded and batched.
- **Grouping**: coupled toolchains land in single PRs so CI validates them together:
  - `kotlin`: Kotlin plugins/artifacts + KSP (compatibility coupled)
  - `compose`: Compose Multiplatform + `org.jetbrains.androidx.*` (lifecycle, navigation)
  - `androidx`: AndroidX artifacts + AGP
  - `ktor`: all Ktor client artifacts
  - `github actions`: all workflow action bumps in one PR, typed `ci`
- **PR titles**: `chore(deps): ...` (actions: `ci(deps): ...`), both pass `pr_name_check.yml`.
- **Gradle wrapper**: updated by the default `gradle-wrapper` manager (enabled via `config:recommended`).
- **stockfish-multiplatform**: current version is a prerelease, so Renovate follows newer alphas (default `ignoreUnstable` behavior), matching the manual bumps done so far (#162).

`config:recommended` also enables the Dependency Dashboard issue.

**Manual step required**: install the Renovate GitHub App on this repo (https://github.com/apps/renovate). Since this config exists on the default branch after merge, Renovate skips onboarding and runs directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)