### PR TITLE
ci: authenticate Renovate against GitHub Packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,14 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
+  "hostRules": [
+    {
+      "matchHost": "maven.pkg.github.com",
+      "hostType": "maven",
+      "username": "Axl-Lvy",
+      "password": "{{ secrets.GH_PACKAGES_TOKEN }}"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
The Dependency Dashboard (#165) reports:

> Renovate failed to look up the following dependencies: `Failed to look up maven package fr.axl-lvy:stockfish-multiplatform: no-result`.

Cause: `stockfish-multiplatform` is resolved from GitHub Packages (`maven.pkg.github.com/Axl-Lvy/Stockfish-Multiplatform`), which requires authentication even for public packages. The hosted Renovate app queried it anonymously and got no result.

Fix: a `hostRules` entry that authenticates Maven lookups against `maven.pkg.github.com` using the `GH_PACKAGES_TOKEN` secret (a PAT with `read:packages`) stored in the Mend portal as a plain secret (not env var), referenced via `{{ secrets.GH_PACKAGES_TOKEN }}` templating.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)