### PR TITLE
ci: group non-major updates into one weekly PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,11 @@
     {
       "groupName": "ktor",
       "matchPackageNames": ["io.ktor*"]
+    },
+    {
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "gradle non-major"
     }
   ]
 }


### PR DESCRIPTION
Reduces Renovate PR volume. A trailing `packageRules` entry routes all **minor and patch** updates from the `gradle` and `gradle-wrapper` managers into a single `gradle non-major` group, so routine bumps arrive as **one weekly PR** with one full tier CI run.

Rule order matters: the catch all comes last, so it overrides the toolchain group names for non-major updates. **Major** updates are untouched by it and keep their per toolchain groups (`kotlin`, `compose`, `androidx`, `ktor`), arriving as separate PRs where a red CI run points directly at the culprit.

GitHub Actions updates keep their own group (typed `ci`); Renovate splits their majors onto a separate branch automatically, so steady state is one actions PR plus occasionally one actions major PR.

Existing open Renovate PRs/branches were created under the old grouping; after this merges, Renovate will autoclose and replace the superseded non-major ones on its next run.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)