### PR TITLE
ci: exclude kotlinx-datetime compat artifacts from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,10 @@
       "matchManagers": ["gradle", "gradle-wrapper"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "gradle non-major"
+    },
+    {
+      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-datetime"],
+      "allowedVersions": "!/compat/"
     }
   ]
 }


### PR DESCRIPTION
Renovate proposed updating kotlinx-datetime from `0.8.0` to `0.8.0-0.6.x-compat` (currently part of #181).

That artifact is not a newer version: since kotlinx-datetime 0.7.0 moved `Instant`/`Clock` into the Kotlin stdlib, JetBrains publishes parallel `-0.6.x-compat` artifacts carrying the deprecated legacy type aliases for consumers stuck on the old API. Maven version ordering sorts unknown qualifiers above the plain release, so Renovate sees it as an upgrade.

`allowedVersions: "!/compat/"` filters those variants out. After merge, Renovate's next refresh of #181 drops the pseudo bump from the group.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)