### PR TITLE
ci: stop auto-update from touching Renovate branches

### DIFF
--- a/.github/workflows/auto_update_prs.yml
+++ b/.github/workflows/auto_update_prs.yml
@@ -25,3 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_FILTER: "all"
+          EXCLUDED_LABELS: "renovate"

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,8 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
+  "labels": ["renovate"],
+  "gitIgnoredAuthors": ["266536929+auto-update[bot]@users.noreply.github.com"],
   "hostRules": [
     {
       "matchHost": "maven.pkg.github.com",


### PR DESCRIPTION
Both open Renovate PRs (#181, #182) are frozen with an "Edited/Blocked Notification": `auto-update[bot]` (from `auto_update_prs.yml`) merged master into the Renovate branches, and Renovate stops maintaining any branch with commits from an author it does not recognize.

Two sided fix:

- `renovate.json`: adds `"labels": ["renovate"]` so every Renovate PR is labeled, and `gitIgnoredAuthors` with the auto-update bot's commit email (`266536929+auto-update[bot]@users.noreply.github.com`) so Renovate ignores its commits when judging whether a PR was manually edited.
- `auto_update_prs.yml`: `EXCLUDED_LABELS: "renovate"` so the auto-update action skips Renovate PRs entirely. Renovate rebases its own PRs when they fall behind, so updating them externally was redundant work (and an extra full tier CI run per master push).

After merge: tick the rebase/retry checkbox on #181 and #182 to reset their branches. The rebase of #181 also drops the `kotlinx-datetime 0.8.0-0.6.x-compat` pseudo update excluded in #183. The label only applies to PRs created after this change; the two existing PRs are covered by `gitIgnoredAuthors`.

Config validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)