### PR TITLE
chore: eliminate actionable build, test, and CI warnings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -159,7 +159,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: false
+          cache-cleanup: never
 
       - name: Run JVM tests with coverage
         env:

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -170,6 +170,9 @@ kotlin {
     wasmJsMain.dependencies {
       implementation(libs.indexeddb)
       implementation(libs.ktor.client.js)
+      // Satisfies the tslib@2 peer dependency declared by memfs (via webpack-dev-server),
+      // which yarn otherwise reports as unmet on every install.
+      implementation(devNpm("tslib", "2.8.1"))
     }
 
     commonTest.dependencies {
@@ -209,6 +212,12 @@ tasks.withType<ComposeHotRun>().configureEach { mainClass = "proj.memorchess.axl
 // Disable the jacoco plugin agent on JVM tests — Kover attaches its own JaCoCo agent via
 // useJacoco(), and two JaCoCo agents on the same JVM crash at class definition time.
 tasks.named<Test>("jvmTest") { extensions.configure<JacocoTaskExtension> { isEnabled = false } }
+
+// Skiko loads its native library through java.lang.System::load, which JDK 24+ flags as
+// restricted and will block by default in a future release.
+tasks.withType<Test>().configureEach { jvmArgs("--enable-native-access=ALL-UNNAMED") }
+
+tasks.withType<JavaExec>().configureEach { jvmArgs("--enable-native-access=ALL-UNNAMED") }
 
 // Disable configuration cache for all tasks involving wasmJs
 tasks.withType<KotlinWebpack>().configureEach {

--- a/composeApp/karma.config.d/resources.js
+++ b/composeApp/karma.config.d/resources.js
@@ -1,0 +1,55 @@
+// Serve compose resources (strings, drawables, fonts) to browser tests, following the setup used
+// by JetBrains in compose-multiplatform's own resources library (components/resources/library/
+// karma.config.d/wasm/config.js). Without this the resource requests issued by the test bundle
+// have nothing to resolve against and every stringResource/painterResource stays unloaded.
+// test_setup.js (from src/wasmJsTest/resources) additionally switches the resource reader to a
+// blocking XMLHttpRequest so reads complete inside the test framework's synchronous waits.
+
+const path = require("path");
+
+const basePath = config.basePath;
+const projectPath = path.resolve(basePath, "..", "..", "..", "..");
+const generatedAssetsPath = path.resolve(projectPath, "build", "karma-webpack-out");
+
+config.proxies["/"] = path.resolve(basePath, "kotlin");
+
+config.files = [
+    {pattern: path.resolve(generatedAssetsPath, "**/*"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.png"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.cvr"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.otf"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.gif"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.ttf"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.txt"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.json"), included: false, served: true, watched: false},
+    {pattern: path.resolve(basePath, "kotlin", "**/*.xml"), included: false, served: true, watched: false},
+    path.resolve(basePath, "kotlin", "test_setup.js"),
+].concat(config.files);
+
+function KarmaWebpackOutputFramework(config) {
+    // This controller is instantiated and set during the preprocessor phase.
+    const controller = config.__karmaWebpackController;
+
+    // only if webpack has instantiated its controller
+    if (!controller) {
+        console.warn(
+            "Webpack has not instantiated controller yet.\n" +
+            "Check if you have enabled webpack preprocessor and framework before this framework"
+        );
+        return;
+    }
+
+    config.files.push({
+        pattern: `${controller.outputPath}/**/*`,
+        included: false,
+        served: true,
+        watched: false
+    });
+}
+
+const KarmaWebpackOutputPlugin = {
+    'framework:webpack-output': ['factory', KarmaWebpackOutputFramework],
+};
+
+config.plugins.push(KarmaWebpackOutputPlugin);
+config.frameworks.push("webpack-output");

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/popup/ConfirmationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/popup/ConfirmationDialog.kt
@@ -64,19 +64,21 @@ class ConfirmationDialog(
       modifier = Modifier.testTag("confirmDialog"),
       buttons = {
         TextButton(
+          modifier = Modifier.testTag("confirmDialogCancelButton"),
           onClick = {
             onConfirm = {}
             show = false
-          }
+          },
         ) {
           Text(stringResource(cancelText))
         }
         TextButton(
+          modifier = Modifier.testTag("confirmDialogOkButton"),
           onClick = {
             onConfirm()
             onConfirm = {}
             show = false
-          }
+          },
         ) {
           Text(stringResource(okText))
         }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/explorer/TestReadableCount.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/explorer/TestReadableCount.kt
@@ -2,7 +2,7 @@ package proj.memorchess.axl.core.data.explorer
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import proj.memorchess.axl.ui.components.explore.LichessExplorerPanelContent
 import proj.memorchess.axl.ui.setKineticContent

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestSettings.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestSettings.kt
@@ -1,10 +1,10 @@
 package proj.memorchess.axl.ui
 
 import androidx.compose.ui.test.*
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.test.runTest
 import org.koin.core.component.inject
 import proj.memorchess.axl.core.config.TRAINING_MOVE_DELAY_SETTING
 import proj.memorchess.axl.core.data.DataNode
@@ -22,13 +22,11 @@ class TestSettings : TestWithKoin() {
 
   private val database: DatabaseQueryManager by inject()
 
-  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) {
+  private fun runTestFromSetup(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     koinSetUp()
     try {
-      runComposeUiTest {
-        setContent { InitializeApp { Settings() } }
-        block()
-      }
+      setContent { InitializeApp { Settings() } }
+      block()
     } finally {
       koinTearDown()
     }
@@ -56,7 +54,7 @@ class TestSettings : TestWithKoin() {
     onNodeWithTag(SETTINGS_SECTION_LIST_TAG).performScrollToNode(hasTestTag("resetConfigButton"))
     assertNodeWithTagExists("resetConfigButton").performClick()
     assertNodeWithTagExists("confirmDialog")
-    assertNodeWithTextExists("OK").performClick()
+    assertNodeWithTagExists("confirmDialogOkButton").performClick()
 
     // Verify the values were reset to defaults
     waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
@@ -66,11 +64,9 @@ class TestSettings : TestWithKoin() {
 
   @Test
   fun testEraseAllDataButton() = runTestFromSetup {
-    runTest {
-      database.insertNodes(
-        DataNode(PositionKey.START_POSITION, PreviousAndNextMoves(), CardStateFactory.new())
-      )
-    }
+    database.insertNodes(
+      DataNode(PositionKey.START_POSITION, PreviousAndNextMoves(), CardStateFactory.new())
+    )
     assertNodeWithTagDoesNotExists("confirmDialog")
 
     // The Danger Zone is the last LazyColumn section, so it is not composed until scrolled into
@@ -80,24 +76,18 @@ class TestSettings : TestWithKoin() {
     // Verify the confirmation dialog appears and click on "Cancel"
     assertNodeWithTagExists("eraseAllDataButton").performClick()
     assertNodeWithTagExists("confirmDialog")
-    assertNodeWithTextExists("Cancel").performClick()
+    assertNodeWithTagExists("confirmDialogCancelButton").performClick()
 
+    val positionsAfterCancel = database.getAllNodes(false)
     assertTrue("Database should not have been cleared after cancel") {
-      getAllPositions().isNotEmpty()
+      positionsAfterCancel.isNotEmpty()
     }
 
     // Verify the confirmation dialog appears and click OK
     assertNodeWithTagExists("eraseAllDataButton").performClick()
-    assertNodeWithTextExists("OK").performClick()
+    assertNodeWithTagExists("confirmDialogOkButton").performClick()
 
     // Verify the database is cleared
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) { getAllPositions().isEmpty() }
-  }
-
-  private fun getAllPositions(): List<DataNode> {
-    var result: List<DataNode>? = null
-    runTest { result = database.getAllNodes(false) }
-    checkNotNull(result)
-    return result
+    waitUntilSuspending { database.getAllNodes(false).isEmpty() }
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
@@ -3,11 +3,10 @@ package proj.memorchess.axl.ui
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration
-import kotlinx.coroutines.test.runTest
 import org.koin.core.component.inject
 import proj.memorchess.axl.core.config.SHORT_TERM_ENABLED_SETTING
 import proj.memorchess.axl.core.config.TRAINING_MOVE_DELAY_SETTING
@@ -22,7 +21,6 @@ import proj.memorchess.axl.core.engine.PieceKind
 import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardState
-import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.TestWithKoin
 import proj.memorchess.axl.ui.pages.Training
 import proj.memorchess.axl.ui.pages.navigation.Route
@@ -34,15 +32,13 @@ class TestTraining : TestWithKoin() {
 
   private val database: DatabaseQueryManager by inject()
 
-  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) {
+  private fun runTestFromSetup(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     koinSetUp()
     disableShortTermScheduler()
     try {
-      runTest { resetDatabase() }
-      runComposeUiTest {
-        setContent { InitializeApp { Training() } }
-        block()
-      }
+      resetDatabase()
+      setContent { InitializeApp { Training() } }
+      block()
     } finally {
       koinTearDown()
     }
@@ -105,21 +101,14 @@ class TestTraining : TestWithKoin() {
     assertNodeWithTextDoesNotExists(BRAVO_TEXT)
     playMove("e2", "e4")
     assertNodeWithTextExists(BRAVO_TEXT)
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
-      val positions = getAllPositions()
+    waitUntilSuspending {
+      val positions = database.getAllNodes(false)
       val now = DateUtil.now()
       positions.size == 1 &&
         positions[0].positionKey == PositionKey.START_POSITION &&
         positions[0].cardState.dueDate > now &&
         positions[0].cardState.lapses == 0
     }
-  }
-
-  private fun getAllPositions(): List<DataNode> {
-    var positions: List<DataNode>? = null
-    runTest { positions = database.getAllNodes(false) }
-    checkNotNull(positions)
-    return positions
   }
 
   @Test
@@ -129,8 +118,8 @@ class TestTraining : TestWithKoin() {
     // No manual click — Training auto-advances Anki-style on wrong moves. With only one card in
     // the deck the "no more cards" Bravo screen appears once the wrong move is graded AGAIN.
     assertNodeWithTextExists(BRAVO_TEXT)
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
-      val positions = getAllPositions()
+    waitUntilSuspending {
+      val positions = database.getAllNodes(false)
       positions.size == 1 &&
         positions[0].positionKey == PositionKey.START_POSITION &&
         positions[0].cardState.lapses >= 1
@@ -170,7 +159,7 @@ class TestTraining : TestWithKoin() {
   }
 
   @Test
-  fun testShowNextMove() {
+  fun testShowNextMove() = runComposeUiTest {
     koinSetUp()
     disableShortTermScheduler()
     try {
@@ -193,35 +182,31 @@ class TestTraining : TestWithKoin() {
           PreviousAndNextMoves(listOf(e4Move), listOf(e5Move)),
           dueNowFromLastWeek(),
         )
-      runTest {
-        resetDatabase()
-        database.insertNodes(testNode)
-      }
-      runComposeUiTest {
-        setContent { InitializeApp { Training() } }
+      resetDatabase()
+      database.insertNodes(testNode)
+      setContent { InitializeApp { Training() } }
 
-        try {
-          assertTileContainsPiece("e4", ChessPiece(PieceKind.PAWN, Player.WHITE), Duration.ZERO)
-          playMove("e7", "e5")
-        } catch (_: Throwable) {
-          playMove("e2", "e4")
-        }
-        assertNodeWithTextDoesNotExists(BRAVO_TEXT)
-        try {
-          assertTileContainsPiece("e4", ChessPiece(PieceKind.PAWN, Player.WHITE), Duration.ZERO)
-          playMove("e7", "e5")
-        } catch (_: Throwable) {
-          playMove("e2", "e4")
-        }
-        assertNodeWithTextExists(BRAVO_TEXT)
+      try {
+        assertTileContainsPiece("e4", ChessPiece(PieceKind.PAWN, Player.WHITE), Duration.ZERO)
+        playMove("e7", "e5")
+      } catch (_: Throwable) {
+        playMove("e2", "e4")
       }
+      assertNodeWithTextDoesNotExists(BRAVO_TEXT)
+      try {
+        assertTileContainsPiece("e4", ChessPiece(PieceKind.PAWN, Player.WHITE), Duration.ZERO)
+        playMove("e7", "e5")
+      } catch (_: Throwable) {
+        playMove("e2", "e4")
+      }
+      assertNodeWithTextExists(BRAVO_TEXT)
     } finally {
       koinTearDown()
     }
   }
 
   @Test
-  fun testPromotion() {
+  fun testPromotion() = runComposeUiTest {
     koinSetUp()
     disableShortTermScheduler()
     try {
@@ -236,17 +221,13 @@ class TestTraining : TestWithKoin() {
           PreviousAndNextMoves(listOf(), listOf(startMove)),
           dueNowFromLastWeek(),
         )
-      runTest {
-        database.eraseAll()
-        database.insertNodes(node)
-      }
-      runComposeUiTest {
-        setContent { InitializeApp { Training() } }
-        assertNodeWithTextDoesNotExists(BRAVO_TEXT)
-        playMove("h7", "h8")
-        promoteTo("queen")
-        assertNodeWithTextExists(BRAVO_TEXT)
-      }
+      database.eraseAll()
+      database.insertNodes(node)
+      setContent { InitializeApp { Training() } }
+      assertNodeWithTextDoesNotExists(BRAVO_TEXT)
+      playMove("h7", "h8")
+      promoteTo("queen")
+      assertNodeWithTextExists(BRAVO_TEXT)
     } finally {
       koinTearDown()
     }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilDoesNotExist
 import co.touchlab.kermit.Logger
 import kotlin.time.Duration
+import kotlin.time.TimeSource
 import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.getNextMoveDescription
@@ -248,6 +249,31 @@ private fun ComposeUiTest.slide(sliderTestTag: String, widthFactor: Float) {
   val width = node.fetchSemanticsNode().size.width
   LOGGER.e { "$width" }
   node.performTouchInput { click(Offset(width * widthFactor, 0f)) }
+}
+
+/**
+ * Like [ComposeUiTest.waitUntil] but accepts a suspending condition.
+ *
+ * [ComposeUiTest.waitUntil] takes a plain lambda, which forces conditions that need suspend APIs
+ * (such as the database) to spin up a nested `runTest`. That cannot work on wasmJs where nothing
+ * can block: the nested test body runs asynchronously and the condition reads a stale value. Tests
+ * running inside the suspending `runComposeUiTest` block call this instead and poll the suspend API
+ * directly, pumping composition between polls.
+ *
+ * @param timeOut The maximum time to wait for the condition to become true
+ * @param condition The suspending condition to poll
+ */
+suspend fun ComposeUiTest.waitUntilSuspending(
+  timeOut: Duration = TEST_TIMEOUT,
+  condition: suspend () -> Boolean,
+) {
+  val mark = TimeSource.Monotonic.markNow()
+  while (!condition()) {
+    if (mark.elapsedNow() > timeOut) {
+      throw AssertionError("Condition still not satisfied after $timeOut")
+    }
+    waitForIdle()
+  }
 }
 
 /**

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestControlBar.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestControlBar.kt
@@ -2,11 +2,10 @@ package proj.memorchess.axl.ui.explore
 
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.koin.core.component.inject
 import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.core.engine.PieceKind
@@ -27,16 +26,14 @@ class TestControlBar : TestWithKoin() {
 
   private val treeStore: TreeStore by inject()
 
-  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) {
+  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
     koinSetUp()
     try {
-      runTest { treeStore.load() }
-      runComposeUiTest {
-        setContent { InitializeApp { Explore() } }
-        playMove("e2", "e4")
-        assertPieceMoved("e2", "e4", ChessPiece(PieceKind.PAWN, Player.WHITE))
-        block()
-      }
+      treeStore.load()
+      setContent { InitializeApp { Explore() } }
+      playMove("e2", "e4")
+      assertPieceMoved("e2", "e4", ChessPiece(PieceKind.PAWN, Player.WHITE))
+      block()
     } finally {
       koinTearDown()
     }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestNextMoveBar.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestNextMoveBar.kt
@@ -3,15 +3,13 @@ package proj.memorchess.axl.ui.explore
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 import org.koin.core.component.inject
 import proj.memorchess.axl.core.data.DatabaseQueryManager
 import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.core.engine.PieceKind
 import proj.memorchess.axl.core.engine.Player
-import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.TestWithKoin
 import proj.memorchess.axl.ui.assertNextMoveExist
 import proj.memorchess.axl.ui.assertPieceMoved
@@ -20,32 +18,27 @@ import proj.memorchess.axl.ui.clickOnReset
 import proj.memorchess.axl.ui.clickOnSave
 import proj.memorchess.axl.ui.pages.Explore
 import proj.memorchess.axl.ui.playMove
+import proj.memorchess.axl.ui.waitUntilSuspending
 
 @OptIn(ExperimentalTestApi::class)
 class TestNextMoveBar : TestWithKoin() {
 
   private val database: DatabaseQueryManager by inject()
 
-  private fun ComposeUiTest.setUp() {
-    runTest { database.eraseAll() }
+  private suspend fun ComposeUiTest.setUp() {
+    database.eraseAll()
     setContent { InitializeApp { Explore() } }
     playMove("e2", "e4")
     assertPieceMoved("e2", "e4", ChessPiece(PieceKind.PAWN, Player.WHITE))
     clickOnSave()
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
-      var size = 0
-      runTest { size = database.getAllNodes(false).size }
-      size == 2
-    }
+    waitUntilSuspending { database.getAllNodes(false).size == 2 }
   }
 
-  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) {
+  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
     koinSetUp()
     try {
-      runComposeUiTest {
-        setUp()
-        block()
-      }
+      setUp()
+      block()
     } finally {
       koinTearDown()
     }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestSaveButton.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestSaveButton.kt
@@ -2,10 +2,9 @@ package proj.memorchess.axl.ui.explore
 
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertNull
-import kotlinx.coroutines.test.runTest
 import org.koin.core.component.inject
 import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.DatabaseQueryManager
@@ -13,12 +12,12 @@ import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.core.engine.PieceKind
 import proj.memorchess.axl.core.engine.Player
-import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.TestWithKoin
 import proj.memorchess.axl.ui.assertPieceMoved
 import proj.memorchess.axl.ui.clickOnSave
 import proj.memorchess.axl.ui.pages.Explore
 import proj.memorchess.axl.ui.playMove
+import proj.memorchess.axl.ui.waitUntilSuspending
 
 @OptIn(ExperimentalTestApi::class)
 class TestSaveButton : TestWithKoin() {
@@ -27,16 +26,14 @@ class TestSaveButton : TestWithKoin() {
   private val afterH6Position = PositionKey("rnbqkbnr/ppppppp1/7p/8/8/7P/PPPPPPP1/RNBQKBNR w KQkq")
   private val database: DatabaseQueryManager by inject()
 
-  private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) {
+  private fun runTestFromSetup(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     koinSetUp()
     try {
-      runTest { database.eraseAll() }
-      runComposeUiTest {
-        setContent { InitializeApp { Explore() } }
-        playMove("h2", "h3")
-        assertPieceMoved("h2", "h3", ChessPiece(PieceKind.PAWN, Player.WHITE))
-        block()
-      }
+      database.eraseAll()
+      setContent { InitializeApp { Explore() } }
+      playMove("h2", "h3")
+      assertPieceMoved("h2", "h3", ChessPiece(PieceKind.PAWN, Player.WHITE))
+      block()
     } finally {
       koinTearDown()
     }
@@ -44,11 +41,11 @@ class TestSaveButton : TestWithKoin() {
 
   @Test
   fun testSaveGood() = runTestFromSetup {
-    assertNull(getPosition(afterH3Position))
+    assertNull(database.getPosition(afterH3Position))
     var savedPosition: DataNode? = null
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
+    waitUntilSuspending {
       clickOnSave()
-      savedPosition = getPosition(afterH3Position)
+      savedPosition = database.getPosition(afterH3Position)
       savedPosition != null
     }
     check(savedPosition!!.previousAndNextMoves.previousMoves.values.all { it.isGood == true })
@@ -58,23 +55,17 @@ class TestSaveButton : TestWithKoin() {
   fun testPropagateSave() = runTestFromSetup {
     playMove("h7", "h6")
     assertPieceMoved("h7", "h6", ChessPiece(PieceKind.PAWN, Player.BLACK))
-    assertNull(getPosition(afterH3Position))
-    assertNull(getPosition(afterH6Position))
+    assertNull(database.getPosition(afterH3Position))
+    assertNull(database.getPosition(afterH6Position))
     var savedLastPosition: DataNode? = null
     var savedFirstPosition: DataNode? = null
-    waitUntil(timeoutMillis = TEST_TIMEOUT.inWholeMilliseconds) {
+    waitUntilSuspending {
       clickOnSave()
-      savedLastPosition = getPosition(afterH6Position)
-      savedFirstPosition = getPosition(afterH3Position)
+      savedLastPosition = database.getPosition(afterH6Position)
+      savedFirstPosition = database.getPosition(afterH3Position)
       savedLastPosition != null && savedFirstPosition != null
     }
     check(savedLastPosition!!.previousAndNextMoves.previousMoves.values.all { it.isGood == true })
     check(savedFirstPosition!!.previousAndNextMoves.previousMoves.values.all { it.isGood == false })
-  }
-
-  private fun getPosition(p: PositionKey): DataNode? {
-    var result: DataNode? = null
-    runTest { result = database.getPosition(p) }
-    return result
   }
 }

--- a/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/auth/OAuthLauncher.ios.kt
+++ b/composeApp/src/iosMain/kotlin/proj/memorchess/axl/core/auth/OAuthLauncher.ios.kt
@@ -51,7 +51,7 @@ actual class OAuthLauncher {
   private fun parseCallback(url: NSURL, expectedState: String): OAuthLaunchResult {
     val components = NSURLComponents.componentsWithURL(url, resolvingAgainstBaseURL = false)
     val items = components?.queryItems?.filterIsInstance<NSURLQueryItem>().orEmpty()
-    val params = items.associate { (it.name ?: "") to (it.value ?: "") }
+    val params = items.associate { it.name to (it.value ?: "") }
     val code = params["code"]
     val state = params["state"]
     return when {

--- a/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/ui/components/explore/TestLichessExplorerPanel.kt
+++ b/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/ui/components/explore/TestLichessExplorerPanel.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import proj.memorchess.axl.core.data.explorer.ExplorerSource
 import proj.memorchess.axl.core.data.explorer.ExplorerState

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/auth/PkceGenerator.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/auth/PkceGenerator.wasmJs.kt
@@ -14,7 +14,7 @@ internal actual fun randomBytes(size: Int): ByteArray {
   cryptoGetRandomValues(buffer)
   val result = ByteArray(size)
   for (i in 0 until size) {
-    result[i] = buffer[i].toByte()
+    result[i] = buffer[i]
   }
   return result
 }

--- a/composeApp/src/wasmJsTest/resources/test_setup.js
+++ b/composeApp/src/wasmJsTest/resources/test_setup.js
@@ -1,0 +1,2 @@
+// Setting this will make the tests use a blocking XMLHttpRequest instead of the asynchronous 'fetch'
+window.composeResourcesTesting = true;

--- a/composeApp/webpack.config.d/performance.js
+++ b/composeApp/webpack.config.d/performance.js
@@ -1,0 +1,5 @@
+// Compose for Web ships multi-megabyte wasm binaries (skiko.wasm alone is ~8 MiB),
+// so webpack's 244 KiB asset-size recommendation can never be met.
+config.performance = Object.assign(config.performance || {}, {
+  hints: false
+});


### PR DESCRIPTION
Closes #190
Closes #191

Investigated every warning emitted by `./gradlew build --warning-mode all` and CI, then fixed all the actionable ones in one pass.

## runComposeUiTest v2 migration (#190)

- All 8 test files now use `androidx.compose.ui.test.v2.runComposeUiTest`.
- The v2 block is suspending, so the nested `runTest { ... }` workarounds are gone: Koin setup and teardown moved inside the block, suspend database calls run directly, and a new `waitUntilSuspending` helper polls suspend APIs between `waitForIdle` pumps.
- Test methods now return the v2 `TestResult`. On wasmJs this makes the browser tests actually await their bodies. With the deprecated API the wrappers discarded the returned promise, so the wasm UI test bodies silently never ran to completion.
- Making the wasm tests real exposed that compose resources (strings, drawables) were never served to Karma. Added the `karma.config.d` resource config and `test_setup.js` (`window.composeResourcesTesting = true`, switching to the blocking XHR resource reader) that JetBrains uses in compose-multiplatform's own resources library.
- Confirmation dialog buttons now carry test tags (`confirmDialogOkButton` / `confirmDialogCancelButton`) and tests click them by tag instead of localized text.

## Other warning fixes

- `OAuthLauncher.ios.kt`: dropped a dead `?:` on the non nullable `NSURLQueryItem.name`.
- `PkceGenerator.wasmJs.kt`: dropped a redundant `.toByte()`.
- Desktop test and run JVMs get `--enable-native-access=ALL-UNNAMED`: Skiko triggers the JDK 24+ restricted `System::load` warning, which will become an error in a future JDK.
- Webpack performance hints disabled (`skiko.wasm` alone is ~8 MiB, the 244 KiB budget can never be met) and the `memfs` unmet `tslib@2` peer dependency satisfied via a dev npm dependency.
- `check.yml`: `gradle-home-cache-cleanup: false` replaced with `cache-cleanup: never` (#191).

## Not fixed (upstream or intentional), for reference

- KLIB duplicate `unique_name` warnings: CMP redistributes androidx klibs; an attempt to pin `lifecycle-viewmodel-savedstate` pulled androidx compose runtime 1.11.2 against CMP 1.11.1 and made it worse, so it was reverted. Resolves when navigation-compose ships against lifecycle 2.10.
- webpack "Critical dependency: the request of a dependency is an expression": Kotlin/Wasm generated loader.
- Configuration cache discarded on full builds: `KotlinWebpack` and Room `RoomSchemaCopyTask` are not serializable (upstream).
- `sun.misc.Unsafe` warning from `kotlin-compiler-embeddable` 2.3.20 inside ktfmt workers, Node `DEP0169 url.parse()` from the wasm tooling, "Type-safe project accessors is an incubating feature", and the intentional `android.experimental.*` emulator snapshot option.

## Verification

- `./gradlew build --warning-mode all`: BUILD SUCCESSFUL, none of the targeted warnings remain.
- JVM: 199 tests, 0 failures.
- wasmJs browser: 184 tests, 0 failures, UI test bodies now genuinely executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)