### PR TITLE
test(perf): add macrobenchmark and JVM microbenchmark performance harnesses

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
 ## Options
 
 - [ ] Force running tests
+- [ ] Run benchmarks

--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -1,0 +1,201 @@
+"""
+Compares a PR benchmark summary against the master baseline window and renders
+the result as a markdown comment.
+
+The baseline is the N most recent summary files (produced by
+extract_benchmark_summary.py) on the benchmark-data branch. For every metric in
+the PR summary the script computes the baseline mean and sample standard
+deviation, then classifies the PR value:
+
+- UI macrobenchmarks run on an emulator and are noisy, so the threshold is
+  max(2 sigma, 1% of the mean); the 1% floor avoids flagging everything when
+  all baseline values happen to be identical (sigma = 0).
+- JVM microbenchmarks are far tighter, so a plain 2 sigma band would flag
+  ordinary runner variance; the threshold is max(2 sigma, 3% of the mean).
+
+The verdict is advisory only: the comment never blocks a merge. The first line
+of the output is an HTML marker so the calling workflow can find and update the
+existing comment instead of stacking new ones.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+COMMENT_MARKER = "<!-- benchmark-comparison -->"
+
+# Minimum baseline entries containing a metric before a verdict is attempted.
+MIN_BASELINE_SAMPLES = 3
+
+SIGMA_MULTIPLIER = 2.0
+MACRO_RELATIVE_FLOOR = 0.01
+MICRO_RELATIVE_FLOOR = 0.03
+
+VERDICT_WITHIN = "✅ within noise"
+VERDICT_REGRESSION = "⚠️ regression"
+VERDICT_IMPROVEMENT = "🟢 improvement"
+VERDICT_NO_BASELINE = "➖ no baseline"
+
+
+def load_baselines(baseline_dir: Path, window: int) -> List[dict]:
+    """Loads the most recent baseline summaries, newest first by filename."""
+    baselines = []
+    for path in sorted(baseline_dir.glob("*.json"), reverse=True)[:window]:
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(data, dict) and "metrics" in data:
+            baselines.append(data)
+    return baselines
+
+
+def format_value(value: float) -> str:
+    """Formats with enough precision for small ms values and large ops/s ones."""
+    if value == 0:
+        return "0"
+    if abs(value) >= 1000:
+        return f"{value:,.0f}"
+    if abs(value) >= 1:
+        return f"{value:.2f}"
+    return f"{value:.4f}"
+
+
+def relative_floor(key: str) -> float:
+    return MACRO_RELATIVE_FLOOR if key.startswith("macro/") else MICRO_RELATIVE_FLOOR
+
+
+def classify(key: str, entry: dict, values: List[float]) -> dict:
+    """Builds one comparison row for a metric present in the PR summary."""
+    pr_value = entry["value"]
+    if len(values) < MIN_BASELINE_SAMPLES:
+        return {
+            "pr": format_value(pr_value),
+            "baseline": f"n={len(values)}",
+            "delta": "n/a",
+            "verdict": VERDICT_NO_BASELINE,
+        }
+
+    mean = statistics.mean(values)
+    sigma = statistics.stdev(values)
+    threshold = max(SIGMA_MULTIPLIER * sigma, relative_floor(key) * abs(mean))
+    delta = pr_value - mean
+
+    if mean != 0:
+        delta_text = f"{delta / abs(mean) * 100:+.1f}%"
+    else:
+        delta_text = f"{delta:+g} (abs)"
+
+    if abs(delta) <= threshold:
+        verdict = VERDICT_WITHIN
+    else:
+        worse = delta > 0 if entry["direction"] == "lower" else delta < 0
+        verdict = VERDICT_REGRESSION if worse else VERDICT_IMPROVEMENT
+
+    return {
+        "pr": format_value(pr_value),
+        "baseline": f"{format_value(mean)} ±{format_value(sigma)} (n={len(values)})",
+        "delta": delta_text,
+        "verdict": verdict,
+    }
+
+
+def render_section(
+    title: str,
+    note: str,
+    prefix: str,
+    pr_metrics: Dict[str, dict],
+    baselines: List[dict],
+) -> List[str]:
+    keys = sorted(k for k in pr_metrics if k.startswith(prefix))
+    if not keys:
+        return []
+    lines = [f"### {title}", "", note, ""]
+    lines.append("| Benchmark | Metric | PR | master | Δ | Verdict |")
+    lines.append("|---|---|---|---|---|---|")
+    for key in keys:
+        entry = pr_metrics[key]
+        values = [
+            b["metrics"][key]["value"] for b in baselines if key in b["metrics"]
+        ]
+        row = classify(key, entry, values)
+        benchmark, metric = split_key(key)
+        unit = f" {entry['unit']}" if entry.get("unit") else ""
+        lines.append(
+            f"| {benchmark} | {metric}{unit} | {row['pr']} | {row['baseline']} "
+            f"| {row['delta']} | {row['verdict']} |"
+        )
+    lines.append("")
+    return lines
+
+
+def split_key(key: str) -> tuple:
+    """Splits a metric key into its benchmark and metric display columns."""
+    parts = key.split("/")
+    if len(parts) == 3:
+        return parts[1], parts[2]
+    return parts[1], "score"
+
+
+def render_comment(
+    pr_summary: dict, baselines: List[dict], run_url: Optional[str]
+) -> str:
+    lines = [COMMENT_MARKER, "## Benchmark comparison", ""]
+    if not baselines:
+        lines.append(
+            "No master baseline data is available yet, so this run only reports "
+            "the PR's own numbers. Baselines accumulate from the daily master "
+            "benchmark run."
+        )
+        lines.append("")
+    lines += render_section(
+        "UI benchmarks (emulator)",
+        "Emulator numbers are noisy; only shifts beyond max(2σ, 1%) of the "
+        "master baseline are flagged.",
+        "macro/",
+        pr_summary["metrics"],
+        baselines,
+    )
+    lines += render_section(
+        "Core microbenchmarks (JVM)",
+        "Shifts beyond max(2σ, 3%) of the master baseline are flagged. "
+        "Throughput scores: higher is better.",
+        "micro/",
+        pr_summary["metrics"],
+        baselines,
+    )
+    lines.append(
+        f"_Advisory only, never blocking. Baseline: {len(baselines)} most recent "
+        "master runs from the `benchmark-data` branch._"
+    )
+    if run_url:
+        lines.append(f"_Raw results: [workflow run]({run_url})._")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-summary", type=Path, required=True)
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--window", type=int, default=10)
+    parser.add_argument("--run-url", default=None)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    pr_summary = json.loads(args.pr_summary.read_text())
+    baselines = (
+        load_baselines(args.baseline_dir, args.window)
+        if args.baseline_dir.is_dir()
+        else []
+    )
+
+    args.output.write_text(render_comment(pr_summary, baselines, args.run_url))
+    print(f"Wrote comparison against {len(baselines)} baseline runs to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/extract_benchmark_summary.py
+++ b/.github/scripts/extract_benchmark_summary.py
@@ -1,0 +1,160 @@
+"""
+Extracts a unified benchmark summary from the merged benchmark-results artifact.
+
+The artifact contains two kinds of result files:
+- Macrobenchmark `benchmarkData.json` files (an object with a `benchmarks` list,
+  each entry holding `metrics` with min/median/max and `sampledMetrics` with
+  percentile distributions). All macro metrics measure time, so lower is better.
+- kotlinx-benchmark / JMH JSON reports (a list of objects with `benchmark`,
+  `mode` and `primaryMetric`). Direction depends on the JMH mode: throughput
+  means higher is better, all time-based modes mean lower is better.
+
+Both are flattened into a single `metrics` map keyed by a stable string
+(`macro/<Class>.<method>/<metric>` or `micro/<Class>.<method>`), each entry
+carrying its value, unit and direction so the comparison script needs no
+knowledge of either source format.
+
+The optional `--prune-dir/--prune-days` pair deletes baseline files whose
+filename date prefix (YYYY-MM-DDTHH-MM) is older than the cutoff, keeping the
+baseline branch bounded.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+SCHEMA_VERSION = 1
+
+# Percentiles kept from Macrobenchmark sampled metrics (e.g. frameDurationCpuMs).
+SAMPLED_PERCENTILES = ("P50", "P90", "P99")
+
+# JMH modes where a higher score is better; every other mode measures time.
+HIGHER_IS_BETTER_MODES = {"thrpt", "Throughput"}
+
+
+def short_name(fully_qualified: str) -> str:
+    """Keeps only the last two dot-separated segments (Class.method)."""
+    return ".".join(fully_qualified.split(".")[-2:])
+
+
+def collect_macro_metrics(macro_dir: Path) -> Dict[str, dict]:
+    """Parses every Macrobenchmark JSON file found under the given directory."""
+    metrics: Dict[str, dict] = {}
+    for path in sorted(macro_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict) or "benchmarks" not in data:
+            continue
+        for benchmark in data["benchmarks"]:
+            simple_class = benchmark.get("className", "").split(".")[-1]
+            bench_key = f"{simple_class}.{benchmark.get('name', '')}"
+            for metric_name, stats in benchmark.get("metrics", {}).items():
+                if "median" not in stats:
+                    continue
+                key = f"macro/{bench_key}/{metric_name}_median"
+                metrics[key] = make_macro_entry(metric_name, stats["median"])
+            for metric_name, stats in benchmark.get("sampledMetrics", {}).items():
+                for percentile in SAMPLED_PERCENTILES:
+                    if percentile not in stats:
+                        continue
+                    key = f"macro/{bench_key}/{metric_name}_{percentile}"
+                    metrics[key] = make_macro_entry(metric_name, stats[percentile])
+    return metrics
+
+
+def make_macro_entry(metric_name: str, value: float) -> dict:
+    unit = "ms" if metric_name.endswith("Ms") else ""
+    return {"value": value, "unit": unit, "direction": "lower"}
+
+
+def collect_micro_metrics(micro_dir: Path) -> Dict[str, dict]:
+    """Parses every JMH JSON report found under the given directory."""
+    metrics: Dict[str, dict] = {}
+    for path in sorted(micro_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if not isinstance(entry, dict) or "benchmark" not in entry:
+                continue
+            primary = entry.get("primaryMetric", {})
+            if "score" not in primary:
+                continue
+            mode = entry.get("mode", "")
+            direction = "higher" if mode in HIGHER_IS_BETTER_MODES else "lower"
+            key = f"micro/{short_name(entry['benchmark'])}"
+            metrics[key] = {
+                "value": primary["score"],
+                "error": primary.get("scoreError"),
+                "unit": primary.get("scoreUnit", ""),
+                "direction": direction,
+            }
+    return metrics
+
+
+def prune_old_runs(runs_dir: Path, max_age_days: int, now: datetime) -> None:
+    """Deletes run files whose filename date prefix is older than the cutoff."""
+    cutoff = now - timedelta(days=max_age_days)
+    for path in runs_dir.glob("*.json"):
+        timestamp = parse_filename_date(path.name)
+        if timestamp is not None and timestamp < cutoff:
+            print(f"Pruning baseline entry older than {max_age_days} days: {path.name}")
+            path.unlink()
+
+
+def parse_filename_date(filename: str) -> Optional[datetime]:
+    try:
+        return datetime.strptime(filename[:16], "%Y-%m-%dT%H-%M").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--macro-dir", type=Path, required=True)
+    parser.add_argument("--micro-dir", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--date", required=True, help="ISO 8601 UTC run date")
+    parser.add_argument("--runner", default="unknown")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prune-dir", type=Path, default=None)
+    parser.add_argument("--prune-days", type=int, default=60)
+    args = parser.parse_args()
+
+    macro = collect_macro_metrics(args.macro_dir) if args.macro_dir.is_dir() else {}
+    micro = collect_micro_metrics(args.micro_dir) if args.micro_dir.is_dir() else {}
+    if not macro and not micro:
+        print("No benchmark results found in either directory.", file=sys.stderr)
+        return 1
+
+    summary = {
+        "schema": SCHEMA_VERSION,
+        "commit": args.commit,
+        "date": args.date,
+        "runner": args.runner,
+        "metrics": {**macro, **micro},
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"Wrote {len(macro)} macro and {len(micro)} micro metrics to {args.output}")
+
+    if args.prune_dir is not None and args.prune_dir.is_dir():
+        now = datetime.fromisoformat(args.date.replace("Z", "+00:00"))
+        prune_old_runs(args.prune_dir, args.prune_days, now)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,0 +1,95 @@
+name: PR benchmarks
+
+# Opt-in PR benchmark comparison: tick "Run benchmarks" in the PR description to run
+# the full benchmark suite (benchmark-run.yml, same procedure as the daily master
+# baseline) and get a sticky comment comparing the results against the rolling window
+# of master baselines stored on the benchmark-data branch. The verdict is advisory
+# only and never blocks a merge.
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Cheap gate so unticked PRs cost seconds, mirroring the "Force running tests"
+  # checkbox handling in check.yml.
+  opt-in:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check the benchmark checkbox
+        id: check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qE '\- \[x\] Run benchmarks'; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    needs: opt-in
+    if: needs.opt-in.outputs.enabled == 'true'
+    uses: ./.github/workflows/benchmark-run.yml
+    secrets: inherit
+
+  compare:
+    runs-on: ubuntu-latest
+    needs: run
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          ref: benchmark-data
+          path: benchmark-data
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          path: results
+
+      - name: Build comparison comment
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 .github/scripts/extract_benchmark_summary.py \
+            --macro-dir results/macrobenchmark-results \
+            --micro-dir results/microbenchmark-results \
+            --commit "$PR_HEAD_SHA" \
+            --date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --runner "$RUNNER_OS" \
+            --output pr-summary.json
+          python3 .github/scripts/compare_benchmarks.py \
+            --pr-summary pr-summary.json \
+            --baseline-dir benchmark-data/runs \
+            --window 10 \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output comment.md
+
+      # Updates the existing comparison comment when one exists (found via the hidden
+      # HTML marker on its first line) instead of stacking a new comment per run.
+      - name: Upsert PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker='<!-- benchmark-comparison -->'
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" | head -n1)"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -F body=@comment.md
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@comment.md
+          fi

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -1,0 +1,109 @@
+name: Benchmark run
+
+# Reusable benchmark execution shared by the daily baseline workflow (benchmark.yml)
+# and the opt-in PR comparison workflow (benchmark-pr.yml), so baseline and PR numbers
+# always come from the exact same measurement procedure. Produces the merged
+# benchmark-results artifact with macrobenchmark-results/ and microbenchmark-results/
+# subdirectories.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+# Consumed by settings.gradle.kts to authenticate against the
+# Stockfish-Multiplatform GitHub Packages repository.
+env:
+  GITHUB_ACTOR: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  macrobenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      # suppressErrors=EMULATOR is required because Macrobenchmark refuses emulators by
+      # default; treat the resulting numbers as relative indicators, not absolute values.
+      - name: Run macrobenchmarks on the Gradle Managed Device
+        run: |
+          ./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: macrobenchmark-results
+          path: |
+            macrobenchmark/build/outputs/**/*.json
+            macrobenchmark/build/outputs/**/*.perfetto-trace
+          retention-days: 30
+
+  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
+  # with the macrobenchmark job.
+  microbenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - name: Run JVM microbenchmarks
+        run: ./gradlew :microbenchmark:benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: microbenchmark-results
+          path: microbenchmark/build/reports/benchmarks/**/*.json
+          retention-days: 30
+
+  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
+  # final job merges their uploads into the single benchmark-results artifact consumers
+  # download. Each source artifact lands in its own subdirectory.
+  merge-results:
+    runs-on: ubuntu-latest
+    needs: [macrobenchmark, microbenchmark]
+    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
+    steps:
+      - name: Merge benchmark artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: benchmark-results
+          pattern: '{macrobenchmark,microbenchmark}-results'
+          separate-directories: true
+          delete-merged: true
+          retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,58 @@
+name: UI performance benchmark
+
+# Manual trigger only: benchmarks take long, need an emulator, and their numbers on shared
+# CI hardware are only useful for relative comparisons, so they stay out of the PR checks.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Consumed by settings.gradle.kts to authenticate against the
+# Stockfish-Multiplatform GitHub Packages repository.
+env:
+  GITHUB_ACTOR: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  macrobenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      # suppressErrors=EMULATOR is required because Macrobenchmark refuses emulators by
+      # default; treat the resulting numbers as relative indicators, not absolute values.
+      - name: Run macrobenchmarks on the Gradle Managed Device
+        run: |
+          ./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: macrobenchmark-results
+          path: |
+            macrobenchmark/build/outputs/**/*.json
+            macrobenchmark/build/outputs/**/*.perfetto-trace
+          retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,107 +1,68 @@
 name: Performance benchmarks
 
-# Manual trigger only: benchmarks take long, the macro job needs an emulator, and their
-# numbers on shared CI hardware are only useful for relative comparisons, so they stay out
-# of the PR checks.
+# Daily baseline run on master, plus manual dispatch. Benchmark numbers on shared CI
+# hardware are only useful for relative comparisons, so each master run is summarized
+# and recorded on the benchmark-data branch; opt-in PR runs (benchmark-pr.yml) compare
+# against the rolling window of those baselines.
 on:
   workflow_dispatch:
+    inputs:
+      record_baseline:
+        description: Record this run in the benchmark-data baseline (master only)
+        type: boolean
+        default: true
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: read
 
-# Consumed by settings.gradle.kts to authenticate against the
-# Stockfish-Multiplatform GitHub Packages repository.
-env:
-  GITHUB_ACTOR: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
-  macrobenchmark:
+  run:
+    uses: ./.github/workflows/benchmark-run.yml
+    secrets: inherit
+
+  # Appends this run's summary to the benchmark-data branch. Guarded to master so the
+  # baseline always describes master; a manual dispatch on any other branch still runs
+  # the benchmarks and uploads the artifact but never touches the baseline. Manual
+  # dispatches on master record too, which allows seeding the baseline window quickly.
+  record-baseline:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    needs: run
+    if: github.ref == 'refs/heads/master' && (github.event_name == 'schedule' || inputs.record_baseline)
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
-      - name: Update local.properties
-        run: .github/scripts/update_properties.sh
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: true
-
-      # suppressErrors=EMULATOR is required because Macrobenchmark refuses emulators by
-      # default; treat the resulting numbers as relative indicators, not absolute values.
-      - name: Run macrobenchmarks on the Gradle Managed Device
-        run: |
-          ./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
-            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
-            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: macrobenchmark-results
-          path: |
-            macrobenchmark/build/outputs/**/*.json
-            macrobenchmark/build/outputs/**/*.perfetto-trace
-          retention-days: 30
-
-  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
-  # with the macrobenchmark job.
-  microbenchmark:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
       - uses: actions/checkout@v6
-
-      - name: Update local.properties
-        run: .github/scripts/update_properties.sh
-
-      - uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          ref: benchmark-data
+          path: benchmark-data
 
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: true
-
-      - name: Run JVM microbenchmarks
-        run: ./gradlew :microbenchmark:benchmark
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: microbenchmark-results
-          path: microbenchmark/build/reports/benchmarks/**/*.json
-          retention-days: 30
-
-  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
-  # final job merges their uploads into the single benchmark-results artifact consumers
-  # download. Each source artifact lands in its own subdirectory.
-  merge-results:
-    runs-on: ubuntu-latest
-    needs: [macrobenchmark, microbenchmark]
-    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
-    steps:
-      - name: Merge benchmark artifacts
-        uses: actions/upload-artifact/merge@v7
+      - uses: actions/download-artifact@v8
         with:
           name: benchmark-results
-          pattern: '{macrobenchmark,microbenchmark}-results'
-          separate-directories: true
-          delete-merged: true
-          retention-days: 30
+          path: results
+
+      - name: Extract run summary
+        run: |
+          stamp="$(date -u +%Y-%m-%dT%H-%M)"
+          python3 .github/scripts/extract_benchmark_summary.py \
+            --macro-dir results/macrobenchmark-results \
+            --micro-dir results/microbenchmark-results \
+            --commit "$GITHUB_SHA" \
+            --date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --runner "$RUNNER_OS" \
+            --output "benchmark-data/runs/${stamp}_${GITHUB_SHA::8}.json" \
+            --prune-dir benchmark-data/runs \
+            --prune-days 60
+
+      - name: Commit baseline entry
+        working-directory: benchmark-data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add runs
+          git commit -m "chore: record benchmark baseline for ${GITHUB_SHA::8}"
+          git push origin benchmark-data

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,8 @@
-name: UI performance benchmark
+name: Performance benchmarks
 
-# Manual trigger only: benchmarks take long, need an emulator, and their numbers on shared
-# CI hardware are only useful for relative comparisons, so they stay out of the PR checks.
+# Manual trigger only: benchmarks take long, the macro job needs an emulator, and their
+# numbers on shared CI hardware are only useful for relative comparisons, so they stay out
+# of the PR checks.
 on:
   workflow_dispatch:
 
@@ -55,4 +56,52 @@ jobs:
           path: |
             macrobenchmark/build/outputs/**/*.json
             macrobenchmark/build/outputs/**/*.perfetto-trace
+          retention-days: 30
+
+  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
+  # with the macrobenchmark job.
+  microbenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - name: Run JVM microbenchmarks
+        run: ./gradlew :microbenchmark:benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: microbenchmark-results
+          path: microbenchmark/build/reports/benchmarks/**/*.json
+          retention-days: 30
+
+  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
+  # final job merges their uploads into the single benchmark-results artifact consumers
+  # download. Each source artifact lands in its own subdirectory.
+  merge-results:
+    runs-on: ubuntu-latest
+    needs: [macrobenchmark, microbenchmark]
+    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
+    steps:
+      - name: Merge benchmark artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: benchmark-results
+          pattern: '{macrobenchmark,microbenchmark}-results'
+          separate-directories: true
+          delete-merged: true
           retention-days: 30

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,14 +190,12 @@ jobs:
           path: composeApp/build/test-results/jvmTest/*.xml
           retention-days: 1
 
-  # Compile safety net. The macrobenchmark module is assembled on both tiers because no
-  # other job builds it: its benchmarks only execute on the manually triggered benchmark
-  # workflow, and build config changes (gradle files, version catalog) resolve to the full
-  # tier where they could otherwise break it unnoticed. The Android + wasm compiles are
-  # cheap tier only: the full tier test jobs already compile every target.
+  # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks, plus the
+  # macrobenchmark module, which no test job builds because its benchmarks only execute on
+  # the manually triggered benchmark workflow.
   compile-multiplat:
     needs: [detect]
-    if: needs.detect.outputs.tier != 'noop'
+    if: needs.detect.outputs.tier == 'cheap'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -214,15 +212,33 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Compile tier-dependent targets
-        env:
-          TIER: ${{ needs.detect.outputs.tier }}
-        run: |
-          if [ "$TIER" = "cheap" ]; then
-            ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
-          else
-            ./gradlew :macrobenchmark:assembleBenchmark
-          fi
+      - name: Compile Android + wasm targets and the macrobenchmark module
+        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
+
+  # Full tier counterpart for the macrobenchmark module only: build config changes (gradle
+  # files, version catalog) resolve to the full tier, where the test jobs compile every
+  # target except this one, so without this job a breaking version bump would pass CI.
+  compile-benchmark:
+    needs: [detect]
+    if: needs.detect.outputs.tier == 'full'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - name: Assemble the macrobenchmark module
+        run: ./gradlew :macrobenchmark:assembleBenchmark
 
   # Full tier: Android instrumented tests, sharded across emulators
   android-tests:
@@ -513,7 +529,7 @@ jobs:
   check-status:
     name: All checks passed
     runs-on: ubuntu-latest
-    needs: [detect, format-check, jvm-tests, compile-multiplat, android-tests, wasm-tests, ios-tests, publish-test-results, sonar-analysis]
+    needs: [detect, format-check, jvm-tests, compile-multiplat, compile-benchmark, android-tests, wasm-tests, ios-tests, publish-test-results, sonar-analysis]
     if: always()
     steps:
       - name: Check job results
@@ -522,6 +538,7 @@ jobs:
           FORMAT: ${{ needs.format-check.result }}
           JVM: ${{ needs.jvm-tests.result }}
           MULTIPLAT: ${{ needs.compile-multiplat.result }}
+          BENCHCOMPILE: ${{ needs.compile-benchmark.result }}
           ANDROID: ${{ needs.android-tests.result }}
           WASM: ${{ needs.wasm-tests.result }}
           IOS: ${{ needs.ios-tests.result }}
@@ -537,12 +554,17 @@ jobs:
             exit 0
           fi
 
-          [ "$FORMAT"    = "success" ] || fail format-check "$FORMAT"
-          [ "$JVM"       = "success" ] || fail jvm-tests "$JVM"
-          [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
-          [ "$PUBLISH"   = "success" ] || fail publish-test-results "$PUBLISH"
+          [ "$FORMAT"  = "success" ] || fail format-check "$FORMAT"
+          [ "$JVM"     = "success" ] || fail jvm-tests "$JVM"
+          [ "$PUBLISH" = "success" ] || fail publish-test-results "$PUBLISH"
+
+          if [ "$TIER" = "cheap" ]; then
+            # sonar runs inside jvm-tests on cheap tier
+            [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
+          fi
 
           if [ "$TIER" = "full" ]; then
+            [ "$BENCHCOMPILE" = "success" ] || fail compile-benchmark "$BENCHCOMPILE"
             [ "$ANDROID" = "success" ] || fail android-tests "$ANDROID"
             [ "$WASM"    = "success" ] || fail wasm-tests "$WASM"
             [ "$IOS"     = "success" ] || fail ios-tests "$IOS"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,10 +190,12 @@ jobs:
           path: composeApp/build/test-results/jvmTest/*.xml
           retention-days: 1
 
-  # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks
+  # Compile safety net, both tiers: Android + wasm to catch expect/actual breaks, and the
+  # macrobenchmark module, which no other job builds because its benchmarks only execute on
+  # the manually triggered benchmark workflow.
   compile-multiplat:
     needs: [detect]
-    if: needs.detect.outputs.tier == 'cheap'
+    if: needs.detect.outputs.tier != 'noop'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -210,8 +212,8 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Compile Android + wasm targets
-        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs
+      - name: Compile Android + wasm targets and the macrobenchmark module
+        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
 
   # Full tier: Android instrumented tests, sharded across emulators
   android-tests:
@@ -526,14 +528,10 @@ jobs:
             exit 0
           fi
 
-          [ "$FORMAT"  = "success" ] || fail format-check "$FORMAT"
-          [ "$JVM"     = "success" ] || fail jvm-tests "$JVM"
-          [ "$PUBLISH" = "success" ] || fail publish-test-results "$PUBLISH"
-
-          if [ "$TIER" = "cheap" ]; then
-            # sonar runs inside jvm-tests on cheap tier
-            [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
-          fi
+          [ "$FORMAT"    = "success" ] || fail format-check "$FORMAT"
+          [ "$JVM"       = "success" ] || fail jvm-tests "$JVM"
+          [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
+          [ "$PUBLISH"   = "success" ] || fail publish-test-results "$PUBLISH"
 
           if [ "$TIER" = "full" ]; then
             [ "$ANDROID" = "success" ] || fail android-tests "$ANDROID"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,12 +190,12 @@ jobs:
           path: composeApp/build/test-results/jvmTest/*.xml
           retention-days: 1
 
-  # Compile safety net, both tiers: Android + wasm to catch expect/actual breaks, and the
+  # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks, plus the
   # macrobenchmark module, which no other job builds because its benchmarks only execute on
   # the manually triggered benchmark workflow.
   compile-multiplat:
     needs: [detect]
-    if: needs.detect.outputs.tier != 'noop'
+    if: needs.detect.outputs.tier == 'cheap'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -528,10 +528,14 @@ jobs:
             exit 0
           fi
 
-          [ "$FORMAT"    = "success" ] || fail format-check "$FORMAT"
-          [ "$JVM"       = "success" ] || fail jvm-tests "$JVM"
-          [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
-          [ "$PUBLISH"   = "success" ] || fail publish-test-results "$PUBLISH"
+          [ "$FORMAT"  = "success" ] || fail format-check "$FORMAT"
+          [ "$JVM"     = "success" ] || fail jvm-tests "$JVM"
+          [ "$PUBLISH" = "success" ] || fail publish-test-results "$PUBLISH"
+
+          if [ "$TIER" = "cheap" ]; then
+            # sonar runs inside jvm-tests on cheap tier
+            [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
+          fi
 
           if [ "$TIER" = "full" ]; then
             [ "$ANDROID" = "success" ] || fail android-tests "$ANDROID"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,12 +190,14 @@ jobs:
           path: composeApp/build/test-results/jvmTest/*.xml
           retention-days: 1
 
-  # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks, plus the
-  # macrobenchmark module, which no other job builds because its benchmarks only execute on
-  # the manually triggered benchmark workflow.
+  # Compile safety net. The macrobenchmark module is assembled on both tiers because no
+  # other job builds it: its benchmarks only execute on the manually triggered benchmark
+  # workflow, and build config changes (gradle files, version catalog) resolve to the full
+  # tier where they could otherwise break it unnoticed. The Android + wasm compiles are
+  # cheap tier only: the full tier test jobs already compile every target.
   compile-multiplat:
     needs: [detect]
-    if: needs.detect.outputs.tier == 'cheap'
+    if: needs.detect.outputs.tier != 'noop'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -212,8 +214,15 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Compile Android + wasm targets and the macrobenchmark module
-        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
+      - name: Compile tier-dependent targets
+        env:
+          TIER: ${{ needs.detect.outputs.tier }}
+        run: |
+          if [ "$TIER" = "cheap" ]; then
+            ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
+          else
+            ./gradlew :macrobenchmark:assembleBenchmark
+          fi
 
   # Full tier: Android instrumented tests, sharded across emulators
   android-tests:
@@ -528,14 +537,10 @@ jobs:
             exit 0
           fi
 
-          [ "$FORMAT"  = "success" ] || fail format-check "$FORMAT"
-          [ "$JVM"     = "success" ] || fail jvm-tests "$JVM"
-          [ "$PUBLISH" = "success" ] || fail publish-test-results "$PUBLISH"
-
-          if [ "$TIER" = "cheap" ]; then
-            # sonar runs inside jvm-tests on cheap tier
-            [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
-          fi
+          [ "$FORMAT"    = "success" ] || fail format-check "$FORMAT"
+          [ "$JVM"       = "success" ] || fail jvm-tests "$JVM"
+          [ "$MULTIPLAT" = "success" ] || fail compile-multiplat "$MULTIPLAT"
+          [ "$PUBLISH"   = "success" ] || fail publish-test-results "$PUBLISH"
 
           if [ "$TIER" = "full" ]; then
             [ "$ANDROID" = "success" ] || fail android-tests "$ANDROID"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -191,8 +191,8 @@ jobs:
           retention-days: 1
 
   # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks, plus the
-  # macrobenchmark module, which no test job builds because its benchmarks only execute on
-  # the manually triggered benchmark workflow.
+  # macrobenchmark and microbenchmark modules, which no test job builds because their
+  # benchmarks only execute on the manually triggered benchmark workflow.
   compile-multiplat:
     needs: [detect]
     if: needs.detect.outputs.tier == 'cheap'
@@ -212,12 +212,12 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Compile Android + wasm targets and the macrobenchmark module
-        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
+      - name: Compile Android + wasm targets and the benchmark modules
+        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark :microbenchmark:assemble
 
-  # Full tier counterpart for the macrobenchmark module only: build config changes (gradle
+  # Full tier counterpart for the benchmark modules only: build config changes (gradle
   # files, version catalog) resolve to the full tier, where the test jobs compile every
-  # target except this one, so without this job a breaking version bump would pass CI.
+  # target except these, so without this job a breaking version bump would pass CI.
   compile-benchmark:
     needs: [detect]
     if: needs.detect.outputs.tier == 'full'
@@ -237,8 +237,8 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Assemble the macrobenchmark module
-        run: ./gradlew :macrobenchmark:assembleBenchmark
+      - name: Assemble the benchmark modules
+        run: ./gradlew :macrobenchmark:assembleBenchmark :microbenchmark:assemble
 
   # Full tier: Android instrumented tests, sharded across emulators
   android-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,18 @@ MemorChess (Anki Chess) is a Kotlin Multiplatform app for memorizing chess openi
 # Code formatting (ktfmt, Google style)
 ./gradlew ktfmtCheck                           # Check formatting
 ./gradlew ktfmtFormat                          # Auto-format
+
+# UI performance benchmarks (Android device/emulator only, see macrobenchmark/README.md)
+./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
 ```
 
 ## Architecture
 
-Two Gradle modules:
+Three Gradle modules:
 
 - **`composeApp`** is the Kotlin Multiplatform library holding all shared code. Its Android target uses the `com.android.kotlin.multiplatform.library` plugin (`kotlin.androidLibrary {}` DSL, no `android {}` block). Source sets: `commonMain`, `androidMain` (platform actuals, OAuth redirect activity, `AndroidContextProvider`), `jvmMain`, `iosMain`, `wasmJsMain`, `nonJsMain` (Room DB shared by Android/JVM/iOS), `debugMain` (hot-reload previews).
-- **`androidApp`** is the thin Android application shell: `MainActivity` (initializes `AndroidContextProvider` and FileKit), launcher manifest and resources, and the instrumented tests (`src/androidTest`). It applies `com.android.application` and relies on the Kotlin support built into AGP 9.
+- **`androidApp`** is the thin Android application shell: `MainActivity` (initializes `AndroidContextProvider` and FileKit), launcher manifest and resources, and the instrumented tests (`src/androidTest`). It applies `com.android.application` and relies on the Kotlin support built into AGP 9. Besides `debug` and `release` it has a `benchmark` build type (release performance, debug signing, profileable) measured by `:macrobenchmark`.
+- **`macrobenchmark`** is a `com.android.test` module holding UI performance benchmarks (`FrameTimingMetric`, `TraceSectionMetric` via Compose composition tracing) that run against the `benchmark` build of `androidApp` on a device or emulator. See `macrobenchmark/README.md`.
 
 The AGP version is capped below 9.1 (renovate rule) because IntelliJ IDEA only syncs AGP versions its Android plugin supports.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,15 +28,19 @@ MemorChess (Anki Chess) is a Kotlin Multiplatform app for memorizing chess openi
 
 # UI performance benchmarks (Android device/emulator only, see macrobenchmark/README.md)
 ./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
+
+# Core logic microbenchmarks (plain JVM, see microbenchmark/README.md)
+./gradlew :microbenchmark:benchmark
 ```
 
 ## Architecture
 
-Three Gradle modules:
+Four Gradle modules:
 
 - **`composeApp`** is the Kotlin Multiplatform library holding all shared code. Its Android target uses the `com.android.kotlin.multiplatform.library` plugin (`kotlin.androidLibrary {}` DSL, no `android {}` block). Source sets: `commonMain`, `androidMain` (platform actuals, OAuth redirect activity, `AndroidContextProvider`), `jvmMain`, `iosMain`, `wasmJsMain`, `nonJsMain` (Room DB shared by Android/JVM/iOS), `debugMain` (hot-reload previews).
 - **`androidApp`** is the thin Android application shell: `MainActivity` (initializes `AndroidContextProvider` and FileKit), launcher manifest and resources, and the instrumented tests (`src/androidTest`). It applies `com.android.application` and relies on the Kotlin support built into AGP 9. Besides `debug` and `release` it has a `benchmark` build type (release performance, debug signing, profileable) measured by `:macrobenchmark`.
 - **`macrobenchmark`** is a `com.android.test` module holding UI performance benchmarks (`FrameTimingMetric`, `TraceSectionMetric` via Compose composition tracing) that run against the `benchmark` build of `androidApp` on a device or emulator. See `macrobenchmark/README.md`.
+- **`microbenchmark`** is a JVM only kotlinx-benchmark (JMH) module measuring the pure Kotlin core of `composeApp` (`GameEngine`, `OpeningTree`/`TreeStore`, `Fsrs6SchedulingAlgorithm`, FEN handling) with deterministic fixtures. It catches algorithmic regressions only; JVM numbers are not ART numbers. See `microbenchmark/README.md`.
 
 The AGP version is capped below 9.1 (renovate rule) because IntelliJ IDEA only syncs AGP versions its Android plugin supports.
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -33,6 +33,15 @@ android {
   buildTypes {
     getByName("release") { isMinifyEnabled = false }
     getByName("debug") { enableAndroidTestCoverage = true }
+    // Build measured by the :macrobenchmark module. Initialized from release so the numbers
+    // are representative, signed with the debug config so it installs on any device, and kept
+    // explicitly not debuggable because Macrobenchmark rejects debuggable targets.
+    create("benchmark") {
+      initWith(getByName("release"))
+      signingConfig = signingConfigs.getByName("debug")
+      matchingFallbacks += listOf("release")
+      isDebuggable = false
+    }
   }
 
   compileOptions {
@@ -133,8 +142,15 @@ extensions.configure<org.sonarqube.gradle.SonarExtension> {
 dependencies {
   implementation(project(":composeApp"))
   implementation(libs.compose.runtime)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.ui)
   implementation(libs.androidx.activity.compose)
   implementation(libs.filekit.dialogs.compose)
+
+  // Makes the Compose runtime emit per composable trace sections in the benchmark build so
+  // the :macrobenchmark TraceSectionMetric can measure board composition. Benchmark variant
+  // only: release and debug builds are unaffected.
+  "benchmarkImplementation"(libs.compose.runtime.tracing)
 
   androidTestImplementation(libs.kotlin.test.junit)
   androidTestImplementation(libs.androidx.room.runtime)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -141,6 +141,11 @@ dependencies {
   // only: release and debug builds are unaffected.
   "benchmarkImplementation"(libs.compose.runtime.tracing)
 
+  // Ships the Perfetto SDK native library inside the benchmark APK. Without it the
+  // benchmark library sideloads the (older) binary it bundles, which the app's
+  // tracing-perfetto runtime rejects with a checksum verification error.
+  "benchmarkImplementation"(libs.androidx.tracing.perfetto.binary)
+
   androidTestImplementation(libs.kotlin.test.junit)
   androidTestImplementation(libs.androidx.room.runtime)
   androidTestImplementation(libs.androidx.ui.test.junit4.android)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -128,17 +128,6 @@ tasks.register<JacocoReport>("jacocoAndroidTestReport") {
   onlyIf { executionData.files.any { it.exists() } }
 }
 
-// The scanner's Android detection already contributes src/main and src/androidTest for
-// this module, so listing them explicitly would index every file twice and abort the
-// analysis. Empty values also stop the root configuration, which lists composeApp source
-// sets that do not exist here, from being inherited.
-extensions.configure<org.sonarqube.gradle.SonarExtension> {
-  properties {
-    property("sonar.sources", "")
-    property("sonar.tests", "")
-  }
-}
-
 dependencies {
   implementation(project(":composeApp"))
   implementation(libs.compose.runtime)

--- a/androidApp/src/benchmark/AndroidManifest.xml
+++ b/androidApp/src/benchmark/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Merged on top of the main manifest for the benchmark build type only. Macrobenchmark
+     requires the target app to be profileable from the shell while staying non debuggable. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <application>
+    <profileable
+      android:shell="true"
+      android:enabled="true"
+      tools:targetApi="30" />
+  </application>
+
+</manifest>

--- a/androidApp/src/main/kotlin/proj/memorchess/axl/MainActivity.kt
+++ b/androidApp/src/main/kotlin/proj/memorchess/axl/MainActivity.kt
@@ -3,6 +3,11 @@ package proj.memorchess.axl
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.init
 import proj.memorchess.axl.ui.KoinStarterApp
@@ -10,10 +15,15 @@ import proj.memorchess.axl.ui.KoinStarterApp
 /** Entry point of the Android app. Wires platform initialization then composes the shared UI. */
 class MainActivity : ComponentActivity() {
 
+  @OptIn(ExperimentalComposeUiApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     AndroidContextProvider.initialize(this)
     FileKit.init(this)
-    setContent { KoinStarterApp() }
+    setContent {
+      // Exposes Compose testTags as accessibility resource ids so UiAutomator (used by the
+      // :macrobenchmark module) can find the bottom navigation items.
+      Box(Modifier.semantics { testTagsAsResourceId = true }) { KoinStarterApp() }
+    }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   // in each subproject's classloader
   alias(libs.plugins.androidApplication) apply false
   alias(libs.plugins.androidKmpLibrary) apply false
+  alias(libs.plugins.androidTest) apply false
   alias(libs.plugins.composeMultiplatform) apply false
   alias(libs.plugins.composeCompiler) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,9 @@ sonar {
       // source sets are still analyzed for code quality (bugs, smells, vulnerabilities).
       // ui/** is excluded because @Composable functions emit synthetic branches that
       // JaCoCo can't filter, inflating uncovered-condition counts on otherwise covered code.
-      "**/build/**,**/generated/**,**/*.gradle.kts,**/R.java,**/BuildConfig.java,**/*Manifest*.xml,**/debugMain/**,**/wasmJsMain/**,**/iosMain/**,**/ui/**,**/main.kt,**/core/auth/OAuthLauncher.*.kt,**/core/auth/LichessOAuthRedirectActivity.kt,**/core/auth/LichessRedirectUri.*.kt",
+      // macrobenchmark/microbenchmark are measurement harnesses verified by running them,
+      // not by unit tests; they stay analyzed for code quality but are exempt from coverage.
+      "**/build/**,**/generated/**,**/*.gradle.kts,**/R.java,**/BuildConfig.java,**/*Manifest*.xml,**/debugMain/**,**/wasmJsMain/**,**/iosMain/**,**/ui/**,**/main.kt,**/core/auth/OAuthLauncher.*.kt,**/core/auth/LichessOAuthRedirectActivity.kt,**/core/auth/LichessRedirectUri.*.kt,**/macrobenchmark/**,**/microbenchmark/**",
     )
 
     // PL/SQL specific configuration for SQL files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
   alias(libs.plugins.composeMultiplatform) apply false
   alias(libs.plugins.composeCompiler) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false
+  alias(libs.plugins.kotlinJvm) apply false
+  alias(libs.plugins.kotlinAllopen) apply false
+  alias(libs.plugins.kotlinxBenchmark) apply false
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.composeHotReload) apply false
   alias(libs.plugins.sonar)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ kover = "0.9.8"
 koin = "4.2.1"
 ktfmt = "0.26.0"
 kotlin = "2.4.0"
+kotlinx-benchmark = "0.4.14"
+kotlinx-coroutines = "1.10.2"
 ksp = "2.3.9"
 kotest = "6.1.11"
 kotlinxDatetime = "0.8.0"
@@ -92,6 +94,8 @@ koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-view
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 androidx-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
@@ -124,7 +128,10 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktfmt = {id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt"}
+kotlinAllopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinxBenchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 kotlinX-serialization-plugin = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 room = { id = "androidx.room", version.ref = "androidx-room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,12 @@ android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"
 androidx-activityCompose = "1.13.0"
+androidx-benchmark = "1.4.1"
 androidx-browser = "1.10.0"
 androidx-lifecycle = "2.10.0"
 androidx-room = "2.8.4"
+androidx-test-ext-junit = "1.3.0"
+androidx-uiautomator = "2.3.0"
 chess-core = "1.0.2"
 composeHotReload = "1.1.1"
 compose-multiplatform = "1.11.1"
@@ -29,6 +32,9 @@ ktor = "3.5.0"
 material-icons = "1.7.3"
 material3-adaptive = "1.2.0"
 material3Android = "1.4.0"
+# Must track the androidx.compose.runtime version that the Compose Multiplatform release
+# above resolves to on Android, otherwise composition tracing produces no sections
+composeRuntimeTracing = "1.11.2"
 multiplatform-settings = "1.3.0"
 navigationComposeVersion = "2.9.2"
 slf4jApi = "2.0.18"
@@ -91,6 +97,10 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 androidx-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestJunit4Android" }
 androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
+androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
+compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "composeRuntimeTracing" }
 
 # --- Logging ---
 kermit-logging = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -108,6 +118,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
+androidTest = { id = "com.android.test", version.ref = "agp" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload"}
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,10 @@ material3Android = "1.4.0"
 # Must track the androidx.compose.runtime version that the Compose Multiplatform release
 # above resolves to on Android, otherwise composition tracing produces no sections
 composeRuntimeTracing = "1.11.2"
+# Must track the androidx.tracing:tracing-perfetto version that compose-runtime-tracing
+# pulls in, otherwise the Perfetto SDK rejects the benchmark native library with a
+# checksum error
+tracingPerfetto = "1.0.1"
 multiplatform-settings = "1.3.0"
 navigationComposeVersion = "2.9.2"
 slf4jApi = "2.0.18"
@@ -105,6 +109,7 @@ androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "composeRuntimeTracing" }
+androidx-tracing-perfetto-binary = { module = "androidx.tracing:tracing-perfetto-binary", version.ref = "tracingPerfetto" }
 
 # --- Logging ---
 kermit-logging = { module = "co.touchlab:kermit", version.ref = "kermit" }

--- a/macrobenchmark/README.md
+++ b/macrobenchmark/README.md
@@ -1,0 +1,73 @@
+# Macrobenchmark
+
+Automated UI performance measurements for the Android app, built on
+[`androidx.benchmark.macro`](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview).
+The benchmarks drive the real app through UiAutomator and measure a build that behaves like a
+release build, so the numbers are representative. Debug builds are roughly 3 to 5 times slower
+because of JIT and runtime checks, which is exactly why these benchmarks exist.
+
+## What is measured
+
+| Benchmark                   | Metric                              | What it tells you                                                                                        |
+|-----------------------------|-------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `ScreenNavigationBenchmark` | `FrameTimingMetric`                 | Frame durations and jank while cycling Explore, Training and Settings through the bottom navigation bar. |
+| `BoardCompositionBenchmark` | `TraceSectionMetric("%BoardGrid%")` | Wall time spent composing the chess board when entering the Explore screen.                              |
+
+## How it works
+
+- `:androidApp` has a `benchmark` build type: initialized from `release`, signed with the debug
+  key so it installs anywhere, explicitly not debuggable (Macrobenchmark refuses debuggable
+  targets), and made profileable from the shell through the manifest overlay in
+  `androidApp/src/benchmark/AndroidManifest.xml`.
+- Board composition is measured without any marker code in the app. The benchmark build adds
+  `androidx.compose.runtime:runtime-tracing` (see `benchmarkImplementation` in
+  `androidApp/build.gradle.kts`), and this module sets the instrumentation argument
+  `androidx.benchmark.fullTracing.enable=true`. Together they make the Compose runtime emit one
+  Perfetto slice per composable, which `TraceSectionMetric` then aggregates. The
+  `composeRuntimeTracing` version in `gradle/libs.versions.toml` must track the
+  `androidx.compose.runtime` version that the Compose Multiplatform release resolves to,
+  otherwise no slices are produced.
+- UiAutomator finds the navigation items through the existing `bottom_navigation_bar_item_*`
+  Compose test tags, exposed as resource ids by the `testTagsAsResourceId` semantics flag set in
+  `MainActivity`.
+
+## Running locally
+
+On a physical device (preferred, the only honest numbers):
+
+```sh
+./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
+```
+
+On an emulator the library refuses to run unless told otherwise, and results are only useful for
+relative comparisons, never absolute values:
+
+```sh
+./gradlew :macrobenchmark:connectedBenchmarkAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
+```
+
+Results are printed in the test output and written as JSON under
+`macrobenchmark/build/outputs/`, including captured Perfetto traces that can be opened in
+[ui.perfetto.dev](https://ui.perfetto.dev).
+
+## Running on the Gradle Managed Device (CI)
+
+A managed virtual device `pixel6Api34` is defined in this module. CI (and anyone without a
+device) can run:
+
+```sh
+./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
+  -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
+```
+
+The `benchmark.yml` workflow wires this up on GitHub Actions behind a manual trigger.
+
+## Interpreting results
+
+- Compare numbers from the same device only. Emulator runs depend on host load.
+- `frameDurationCpuMs` percentiles (P50/P90/P95/P99) are the headline numbers for navigation.
+- For `BoardCompositionBenchmark`, composition tracing itself adds a small overhead to every
+  composable, so use its `FrameTimingMetric` values as relative indicators only;
+  `ScreenNavigationBenchmark` is the clean frame timing source.

--- a/macrobenchmark/build.gradle.kts
+++ b/macrobenchmark/build.gradle.kts
@@ -76,16 +76,6 @@ tasks.named("ktfmtFormat") { dependsOn(ktfmtFormatBenchmarkSources) }
 
 tasks.named("ktfmtCheck") { dependsOn(ktfmtCheckBenchmarkSources) }
 
-// Benchmarks are not application code: keep them out of the Sonar analysis. Empty values
-// also stop the root configuration, which lists composeApp source sets that do not exist
-// here, from being inherited.
-extensions.configure<org.sonarqube.gradle.SonarExtension> {
-  properties {
-    property("sonar.sources", "")
-    property("sonar.tests", "")
-  }
-}
-
 dependencies {
   implementation(libs.androidx.benchmark.macro.junit4)
   implementation(libs.androidx.test.ext.junit)

--- a/macrobenchmark/build.gradle.kts
+++ b/macrobenchmark/build.gradle.kts
@@ -1,0 +1,93 @@
+import com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask
+import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  alias(libs.plugins.androidTest)
+  alias(libs.plugins.ktfmt)
+}
+
+android {
+  namespace = "proj.memorchess.axl.macrobenchmark"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+  defaultConfig {
+    minSdk = libs.versions.android.minSdk.get().toInt()
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    // Required for the TraceSectionMetric: makes Macrobenchmark enable the Perfetto SDK
+    // tracing that the runtime-tracing artifact in the target app emits through.
+    testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+  }
+
+  buildTypes {
+    // Matches the benchmark build type of :androidApp so both APKs install together. The
+    // test APK itself may stay debuggable; only the target app must not be.
+    create("benchmark") {
+      isDebuggable = true
+      signingConfig = getByName("debug").signingConfig
+      matchingFallbacks += listOf("release")
+    }
+  }
+
+  targetProjectPath = ":androidApp"
+  // The benchmark instruments itself against the separately installed target app instead of
+  // loading the app into the instrumentation process.
+  experimentalProperties["android.experimental.self-instrumenting"] = true
+
+  testOptions {
+    managedDevices {
+      localDevices {
+        create("pixel6Api34") {
+          device = "Pixel 6"
+          apiLevel = 34
+          systemImageSource = "aosp"
+        }
+      }
+    }
+  }
+}
+
+kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_21) } }
+
+// Only the benchmark variant makes sense for this module.
+androidComponents { beforeVariants(selector().all()) { it.enable = it.buildType == "benchmark" } }
+
+ktfmt { googleStyle() }
+
+// The ktfmt plugin does not detect source sets compiled by the Kotlin support built into
+// AGP 9, so the Kotlin sources of this module are wired up manually.
+val ktfmtFormatBenchmarkSources =
+  tasks.register<KtfmtFormatTask>("ktfmtFormatBenchmarkSources") {
+    source = fileTree("src") { include("**/*.kt") }
+  }
+
+val ktfmtCheckBenchmarkSources =
+  tasks.register<KtfmtCheckTask>("ktfmtCheckBenchmarkSources") {
+    source = fileTree("src") { include("**/*.kt") }
+  }
+
+tasks.named("ktfmtFormat") { dependsOn(ktfmtFormatBenchmarkSources) }
+
+tasks.named("ktfmtCheck") { dependsOn(ktfmtCheckBenchmarkSources) }
+
+// Benchmarks are not application code: keep them out of the Sonar analysis. Empty values
+// also stop the root configuration, which lists composeApp source sets that do not exist
+// here, from being inherited.
+extensions.configure<org.sonarqube.gradle.SonarExtension> {
+  properties {
+    property("sonar.sources", "")
+    property("sonar.tests", "")
+  }
+}
+
+dependencies {
+  implementation(libs.androidx.benchmark.macro.junit4)
+  implementation(libs.androidx.test.ext.junit)
+  implementation(libs.androidx.uiautomator)
+}

--- a/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BenchmarkNavigation.kt
+++ b/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BenchmarkNavigation.kt
@@ -1,0 +1,26 @@
+package proj.memorchess.axl.macrobenchmark
+
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+
+/** Application id of the app under benchmark. */
+internal const val TARGET_PACKAGE = "proj.memorchess.axl"
+
+private const val UI_TIMEOUT_MS = 10_000L
+
+/**
+ * Taps the bottom navigation item leading to the destination labeled [label] and waits for the UI
+ * to settle.
+ *
+ * Relies on `testTagsAsResourceId` being enabled in `MainActivity`, which exposes the
+ * `bottom_navigation_bar_item_*` Compose test tags as resource ids that UiAutomator can find.
+ */
+internal fun MacrobenchmarkScope.navigateTo(label: String) {
+  val tag = "bottom_navigation_bar_item_$label"
+  check(device.wait(Until.hasObject(By.res(tag)), UI_TIMEOUT_MS)) {
+    "Bottom navigation item '$tag' not found on screen"
+  }
+  device.findObject(By.res(tag)).click()
+  device.waitForIdle()
+}

--- a/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BoardCompositionBenchmark.kt
+++ b/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BoardCompositionBenchmark.kt
@@ -1,0 +1,48 @@
+package proj.memorchess.axl.macrobenchmark
+
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.TraceSectionMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Measures how long composing the chess board takes when entering the Explore screen.
+ *
+ * The `BoardGrid` trace sections come from Compose composition tracing: the benchmark build of the
+ * app ships `androidx.compose.runtime:runtime-tracing`, and this module enables
+ * `androidx.benchmark.fullTracing.enable`, which makes the Compose runtime emit one Perfetto slice
+ * per composable. No marker code exists in the app itself.
+ *
+ * Each iteration starts on Settings (no board) and measures the navigation into Explore, so the
+ * board is composed from scratch inside the measured window. Composition tracing adds a small
+ * overhead to every composable, so treat the accompanying frame timing numbers as relative
+ * indicators only; [ScreenNavigationBenchmark] is the clean frame timing source.
+ */
+@OptIn(ExperimentalMetricApi::class)
+@RunWith(AndroidJUnit4::class)
+class BoardCompositionBenchmark {
+
+  @get:Rule val benchmarkRule = MacrobenchmarkRule()
+
+  @Test
+  fun boardCompositionOnExploreEntry() {
+    benchmarkRule.measureRepeated(
+      packageName = TARGET_PACKAGE,
+      metrics =
+        listOf(TraceSectionMetric("%BoardGrid%", TraceSectionMetric.Mode.Sum), FrameTimingMetric()),
+      iterations = 10,
+      startupMode = StartupMode.WARM,
+      setupBlock = {
+        startActivityAndWait()
+        navigateTo("Settings")
+      },
+    ) {
+      navigateTo("Explore")
+    }
+  }
+}

--- a/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/ScreenNavigationBenchmark.kt
+++ b/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/ScreenNavigationBenchmark.kt
@@ -1,0 +1,37 @@
+package proj.memorchess.axl.macrobenchmark
+
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Measures frame timing (jank, dropped frames) while cycling through the three main screens via the
+ * bottom navigation bar, the way a user would.
+ *
+ * App startup happens in the setup block, so the measured window contains only the screen
+ * transitions themselves.
+ */
+@RunWith(AndroidJUnit4::class)
+class ScreenNavigationBenchmark {
+
+  @get:Rule val benchmarkRule = MacrobenchmarkRule()
+
+  @Test
+  fun screenTransitions() {
+    benchmarkRule.measureRepeated(
+      packageName = TARGET_PACKAGE,
+      metrics = listOf(FrameTimingMetric()),
+      iterations = 10,
+      startupMode = StartupMode.WARM,
+      setupBlock = { startActivityAndWait() },
+    ) {
+      navigateTo("Training")
+      navigateTo("Settings")
+      navigateTo("Explore")
+    }
+  }
+}

--- a/microbenchmark/README.md
+++ b/microbenchmark/README.md
@@ -1,0 +1,54 @@
+# Microbenchmark
+
+JVM microbenchmarks for the pure Kotlin core of `:composeApp`, built on
+[kotlinx-benchmark](https://github.com/Kotlin/kotlinx-benchmark) (JMH under the hood). They
+complement `:macrobenchmark`: that module measures the rendered Android UI, this one measures the
+algorithms underneath it, with no device or emulator required.
+
+## What is measured
+
+| Benchmark                  | What it guards                                                                                          |
+|----------------------------|---------------------------------------------------------------------------------------------------------|
+| `GameEngineBenchmark`      | SAN move validation and FEN production while replaying opening lines, the per move hot path of the app. |
+| `OpeningTreeBenchmark`     | Building the opening graph through `TreeStore` and the lookup path used on every navigation step.       |
+| `Fsrs6SchedulingBenchmark` | A full FSRS 6 scheduling pass over a card batch covering every `ReviewGrade` and `CardPhase`.            |
+| `FenBenchmark`             | Parsing cropped FENs into engines and cropping positions back into `PositionKey`s.                       |
+
+All inputs are deterministic fixtures (`OpeningLines`); the FSRS fuzz source is a constant. Runs
+are therefore comparable across machines, up to hardware differences.
+
+## Running locally
+
+```sh
+./gradlew :microbenchmark:benchmark
+```
+
+The full suite takes a few minutes. For a quick check that every benchmark still executes (numbers
+are meaningless at these settings):
+
+```sh
+./gradlew :microbenchmark:mainSmokeBenchmark
+```
+
+## Reading the output
+
+JMH reports throughput in `ops/s`: one op is one whole benchmark method invocation, for example
+replaying all sixteen fixture lines, not a single move. Higher is better. The console prints a
+summary table; machine readable JSON lands under
+`microbenchmark/build/reports/benchmarks/<configuration>/<timestamp>/main.json` with `score`,
+`scoreError` and percentile fields per benchmark. Compare the `score` of the same benchmark across
+runs and treat differences within `scoreError` as noise.
+
+## Caveat: JVM numbers are not Android numbers
+
+These benchmarks run on a desktop JVM (HotSpot with C2). The app ships on ART, a different runtime
+with a different compiler, allocator and GC. Absolute values do not transfer. What does transfer is
+algorithmic complexity: a change that makes graph construction quadratic or doubles the work per
+SAN move shows up here regardless of runtime. Use this module to catch algorithmic regressions in
+core logic; use `:macrobenchmark` for realistic on device UI performance.
+
+## CI
+
+The manually triggered `benchmark.yml` workflow runs this suite in a `microbenchmark` job, in
+parallel with the `macrobenchmark` job, then merges both JSON result sets into a single
+`benchmark-results` artifact with one subdirectory per module.

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -1,0 +1,73 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.kotlinxBenchmark)
+  alias(libs.plugins.kotlinAllopen)
+  alias(libs.plugins.ktfmt)
+}
+
+// JMH requires benchmark state classes to be open; the Kotlin allopen plugin lifts the
+// restriction for every class annotated with JMH's @State.
+allOpen { annotation("org.openjdk.jmh.annotations.State") }
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_21)
+    // Edge and CardState expose kotlin.time.Instant in their public API.
+    optIn.add("kotlin.time.ExperimentalTime")
+  }
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_21
+  targetCompatibility = JavaVersion.VERSION_21
+}
+
+benchmark {
+  targets { register("main") }
+
+  configurations {
+    named("main") {
+      // Small but stable run: enough iterations for JMH to settle on the hot path while
+      // keeping the whole suite well under ten minutes.
+      warmups = 3
+      iterations = 5
+      iterationTime = 500
+      iterationTimeUnit = "ms"
+      // JSON keeps the results machine readable so CI can merge them with the
+      // macrobenchmark output into a single artifact.
+      reportFormat = "json"
+      advanced("jvmForks", "1")
+    }
+
+    // Minimal run proving every benchmark still executes; numbers are meaningless.
+    register("smoke") {
+      warmups = 1
+      iterations = 1
+      iterationTime = 100
+      iterationTimeUnit = "ms"
+      reportFormat = "json"
+      advanced("jvmForks", "1")
+    }
+  }
+}
+
+ktfmt { googleStyle() }
+
+// Benchmarks are not application code: keep them out of the Sonar analysis. Empty values
+// also stop the root configuration, which lists composeApp source sets that do not exist
+// here, from being inherited.
+extensions.configure<org.sonarqube.gradle.SonarExtension> {
+  properties {
+    property("sonar.sources", "")
+    property("sonar.tests", "")
+  }
+}
+
+dependencies {
+  implementation(projects.composeApp)
+  implementation(libs.kotlinx.benchmark.runtime)
+  // TreeStore's mutation API is suspending; benchmarks bridge it with runBlocking.
+  implementation(libs.kotlinx.coroutines.core)
+}

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -55,16 +55,6 @@ benchmark {
 
 ktfmt { googleStyle() }
 
-// Benchmarks are not application code: keep them out of the Sonar analysis. Empty values
-// also stop the root configuration, which lists composeApp source sets that do not exist
-// here, from being inherited.
-extensions.configure<org.sonarqube.gradle.SonarExtension> {
-  properties {
-    property("sonar.sources", "")
-    property("sonar.tests", "")
-  }
-}
-
 dependencies {
   implementation(projects.composeApp)
   implementation(libs.kotlinx.benchmark.runtime)

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/FenBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/FenBenchmark.kt
@@ -1,0 +1,60 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Measures the conversions between board state and the FEN derived string forms: parsing a cropped
+ * FEN back into a [GameEngine] and cropping a live position down to a [PositionKey].
+ *
+ * Guards against regressions in position identity handling. Every persisted node is keyed by its
+ * cropped FEN, so parsing runs for each node when entering a stored position and cropping runs
+ * after every move; both are also the backbone of database loading.
+ */
+@State(Scope.Benchmark)
+class FenBenchmark {
+
+  private var positionKeys: List<PositionKey> = emptyList()
+
+  private var engines: List<GameEngine> = emptyList()
+
+  @Setup
+  fun setup() {
+    val edges = OpeningLines.replayToEdges()
+    positionKeys =
+      (listOf(PositionKey.START_POSITION) + edges.map { it.to }).distinctBy { it.value }
+    engines = positionKeys.map { GameEngine(it) }
+  }
+
+  /**
+   * Rebuilds a [GameEngine] from every distinct cropped FEN of the fixture graph.
+   *
+   * Guards the cropped FEN completion and board parsing cost paid for every position opened from
+   * the database, for example when a training card is shown.
+   */
+  @Benchmark
+  fun parseCroppedFens(bh: Blackhole) {
+    for (key in positionKeys) {
+      bh.consume(GameEngine(key).toFen())
+    }
+  }
+
+  /**
+   * Produces the [PositionKey] and the full FEN of every prebuilt position.
+   *
+   * Guards the FEN cropping path, including the en passant relevance check, which runs after every
+   * move played anywhere in the app.
+   */
+  @Benchmark
+  fun cropPositionsToKeys(bh: Blackhole) {
+    for (engine in engines) {
+      bh.consume(engine.toPositionKey())
+      bh.consume(engine.toFen())
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/Fsrs6SchedulingBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/Fsrs6SchedulingBenchmark.kt
@@ -1,0 +1,87 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.scheduling.CardPhase
+import proj.memorchess.axl.core.scheduling.CardState
+import proj.memorchess.axl.core.scheduling.Fsrs6SchedulingAlgorithm
+import proj.memorchess.axl.core.scheduling.ReviewGrade
+
+/**
+ * Measures a full [Fsrs6SchedulingAlgorithm] scheduling pass over a deterministic batch of
+ * [CardState] values covering every [ReviewGrade], every [CardPhase], and a first review.
+ *
+ * Guards against regressions in the FSRS math (forgetting curve, stability and difficulty updates,
+ * interval fuzz). The trainer schedules every reviewed position synchronously on the UI thread, so
+ * a slowdown here directly delays the next card after each answer. The fuzz source is a constant so
+ * results never depend on randomness.
+ */
+@State(Scope.Benchmark)
+class Fsrs6SchedulingBenchmark {
+
+  private val now: Instant = Instant.parse("2026-01-01T00:00:00Z")
+
+  /** Short term scheduler with the learning step ladders active, the app's default mode. */
+  private val shortTermAlgorithm =
+    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 }, enableShortTerm = { true })
+
+  /** Long term only scheduler, the mode used when the user disables learning steps. */
+  private val longTermAlgorithm =
+    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 }, enableShortTerm = { false })
+
+  private var cards: List<CardState?> = emptyList()
+
+  @Setup
+  fun setup() {
+    // One null entry exercises the first review path; the rest sweep phases, learning steps,
+    // elapsed times, stabilities and difficulties with fixed arithmetic progressions.
+    cards =
+      listOf(null) +
+        (0 until 100).map { i ->
+          CardState(
+            dueDate = now,
+            lastReview = now - ((i % 30) + 1).days,
+            stability = 0.4 + i * 0.37,
+            difficulty = 1.0 + (i % 91) / 10.0,
+            reps = i,
+            lapses = i % 5,
+            phase = CardPhase.entries[i % CardPhase.entries.size],
+            step = i % 2,
+          )
+        }
+  }
+
+  /**
+   * Schedules every card of the batch with all four grades through the short term state machine.
+   *
+   * Guards the learning and relearning routing on top of the core FSRS math.
+   */
+  @Benchmark
+  fun shortTermSchedulingPass(bh: Blackhole) {
+    for (card in cards) {
+      for (grade in ReviewGrade.entries) {
+        bh.consume(shortTermAlgorithm.schedule(card, grade, now))
+      }
+    }
+  }
+
+  /**
+   * Schedules every card of the batch with all four grades through the long term path, which
+   * computes candidate intervals for all grades and enforces their monotonic ordering.
+   *
+   * Guards the heavier all grades candidate computation of the long term scheduler.
+   */
+  @Benchmark
+  fun longTermSchedulingPass(bh: Blackhole) {
+    for (card in cards) {
+      for (grade in ReviewGrade.entries) {
+        bh.consume(longTermAlgorithm.schedule(card, grade, now))
+      }
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/GameEngineBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/GameEngineBenchmark.kt
@@ -1,0 +1,54 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Measures [GameEngine] on the hot path of both exploration and training: validating and applying
+ * SAN moves, then producing the position identity used to key the opening graph.
+ *
+ * Guards against regressions in move validation and FEN production, the two operations executed on
+ * every single move a user plays. A slowdown here multiplies across the whole app because every
+ * interaction controller funnels moves through [GameEngine].
+ */
+@State(Scope.Benchmark)
+class GameEngineBenchmark {
+
+  /**
+   * Plays all fixture lines move by move from the starting position and reads the final FEN.
+   *
+   * Guards the SAN parsing and legal move generation cost of [GameEngine.playSanMove], the exact
+   * work done when replaying stored lines.
+   */
+  @Benchmark
+  fun playSanLines(bh: Blackhole) {
+    for (line in OpeningLines.SAN_LINES) {
+      val engine = GameEngine()
+      for (san in line) {
+        engine.playSanMove(san)
+      }
+      bh.consume(engine.toFen())
+    }
+  }
+
+  /**
+   * Plays all fixture lines and derives a [proj.memorchess.axl.core.data.PositionKey] after every
+   * ply, exactly as the explorer does to look up each reached position in the opening graph.
+   *
+   * Guards the combined cost of move application plus FEN cropping, including the en passant
+   * relevance check.
+   */
+  @Benchmark
+  fun positionKeyAfterEveryMove(bh: Blackhole) {
+    for (line in OpeningLines.SAN_LINES) {
+      val engine = GameEngine()
+      for (san in line) {
+        engine.playSanMove(san)
+        bh.consume(engine.toPositionKey())
+      }
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
@@ -1,0 +1,31 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlin.time.Instant
+import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.DatabaseQueryManager
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.graph.DeleteMode
+
+/**
+ * [DatabaseQueryManager] that persists nothing.
+ *
+ * Benchmarks plug it into [proj.memorchess.axl.core.graph.TreeStore] so that graph mutation
+ * measurements cover the full store logic, including the conversion of nodes to their persisted
+ * shape, without any platform database I/O skewing the numbers.
+ */
+class NoOpDatabaseQueryManager : DatabaseQueryManager {
+
+  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> = emptyList()
+
+  override suspend fun getPosition(positionKey: PositionKey): DataNode? = null
+
+  override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) = Unit
+
+  override suspend fun deleteMove(origin: PositionKey, move: String, mode: DeleteMode) = Unit
+
+  override suspend fun eraseAll() = Unit
+
+  override suspend fun insertNodes(vararg positions: DataNode) = Unit
+
+  override suspend fun getLastUpdate(): Instant? = null
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningLines.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningLines.kt
@@ -1,0 +1,88 @@
+package proj.memorchess.axl.microbenchmark
+
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Deterministic benchmark fixture: sixteen well known opening main lines, twenty plies each, given
+ * in marker free SAN exactly as the app stores moves.
+ *
+ * The fixture is the single source of inputs for every benchmark in this module so that runs stay
+ * comparable across machines and over time. Changing a line invalidates historical comparisons; add
+ * new lines instead of editing existing ones.
+ */
+object OpeningLines {
+
+  /** One entry per opening, each a sequence of SAN moves playable from the starting position. */
+  val SAN_LINES: List<List<String>> =
+    listOf(
+        // Ruy Lopez, Breyer
+        "e4 e5 Nf3 Nc6 Bb5 a6 Ba4 Nf6 O-O Be7 Re1 b5 Bb3 d6 c3 O-O h3 Nb8 d4 Nbd7",
+        // Italian, Giuoco Pianissimo
+        "e4 e5 Nf3 Nc6 Bc4 Bc5 c3 Nf6 d3 d6 O-O a6 a4 Ba7 Re1 O-O h3 Be6 Bxe6 fxe6",
+        // Sicilian, Najdorf English Attack
+        "e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Be3 e5 Nb3 Be6 f3 Be7 Qd2 O-O O-O-O Nbd7",
+        // Sicilian, Sveshnikov
+        "e4 c5 Nf3 Nc6 d4 cxd4 Nxd4 Nf6 Nc3 e5 Ndb5 d6 Bg5 a6 Na3 b5 Nd5 Be7 Bxf6 Bxf6",
+        // French, Winawer poisoned pawn
+        "e4 e6 d4 d5 Nc3 Bb4 e5 c5 a3 Bxc3 bxc3 Ne7 Qg4 Qc7 Qxg7 Rg8 Qxh7 cxd4 Ne2 Nbc6",
+        // Caro Kann, Classical
+        "e4 c6 d4 d5 Nc3 dxe4 Nxe4 Bf5 Ng3 Bg6 h4 h6 Nf3 Nd7 h5 Bh7 Bd3 Bxd3 Qxd3 e6",
+        // Queen's Gambit Declined, Tartakower
+        "d4 d5 c4 e6 Nc3 Nf6 Bg5 Be7 e3 O-O Nf3 h6 Bh4 b6 Be2 Bb7 Bxf6 Bxf6 cxd5 exd5",
+        // Slav, Czech main line
+        "d4 d5 c4 c6 Nf3 Nf6 Nc3 dxc4 a4 Bf5 e3 e6 Bxc4 Bb4 O-O O-O Qe2 Nbd7",
+        // King's Indian, Classical
+        "d4 Nf6 c4 g6 Nc3 Bg7 e4 d6 Nf3 O-O Be2 e5 O-O Nc6 d5 Ne7 Ne1 Nd7 Be3 f5",
+        // Nimzo Indian, Rubinstein
+        "d4 Nf6 c4 e6 Nc3 Bb4 e3 O-O Bd3 d5 Nf3 c5 O-O Nc6 a3 Bxc3 bxc3 dxc4 Bxc4 Qc7",
+        // Gruenfeld, Exchange
+        "d4 Nf6 c4 g6 Nc3 d5 cxd5 Nxd5 e4 Nxc3 bxc3 Bg7 Nf3 c5 Rb1 O-O Be2 cxd4 cxd4 Qa5",
+        // English, Four Knights reversed dragon
+        "c4 e5 Nc3 Nf6 Nf3 Nc6 g3 d5 cxd5 Nxd5 Bg2 Nb6 O-O Be7 d3 O-O a3 Be6 b4 a5",
+        // London System
+        "d4 d5 Bf4 Nf6 e3 c5 Nf3 Nc6 c3 e6 Nbd2 Bd6 Bg3 O-O Bd3 b6 e4 dxe4 Nxe4 Be7",
+        // Scotch, Mieses
+        "e4 e5 Nf3 Nc6 d4 exd4 Nxd4 Nf6 Nxc6 bxc6 e5 Qe7 Qe2 Nd5 c4 Ba6 b3 g6 g3 Bg7",
+        // Catalan, Open
+        "d4 Nf6 c4 e6 g3 d5 Bg2 Be7 Nf3 O-O O-O dxc4 Qc2 a6 Qxc4 b5 Qc2 Bb7 Bd2 Be4",
+        // Petroff, Classical
+        "e4 e5 Nf3 Nf6 Nxe5 d6 Nf3 Nxe4 d4 d5 Bd3 Nc6 O-O Be7 c4 Nb4 Be2 O-O Nc3 Bf5",
+      )
+      .map { it.split(" ") }
+
+  /**
+   * One graph edge produced by replaying the fixture lines.
+   *
+   * @property from Position the move is played from.
+   * @property san The move in marker free SAN.
+   * @property to Position reached after the move.
+   * @property fromDepth Ply distance of [from] from the starting position.
+   */
+  data class MoveEdge(
+    val from: PositionKey,
+    val san: String,
+    val to: PositionKey,
+    val fromDepth: Int,
+  )
+
+  /**
+   * Replays every line through [GameEngine] and returns the deduplicated edge list, in first
+   * occurrence order. Lines share their early plies, so the result is a tree shaped graph of a few
+   * hundred positions, the realistic size of a personal opening repertoire.
+   */
+  fun replayToEdges(): List<MoveEdge> {
+    val edges = LinkedHashMap<Pair<PositionKey, String>, MoveEdge>()
+    for (line in SAN_LINES) {
+      val engine = GameEngine()
+      var fromKey = engine.toPositionKey()
+      line.forEachIndexed { ply, san ->
+        engine.playSanMove(san)
+        val toKey = engine.toPositionKey()
+        edges.getOrPut(fromKey to san) { MoveEdge(fromKey, san, toKey, ply) }
+        fromKey = toKey
+      }
+    }
+    return edges.values.toList()
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningTreeBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningTreeBenchmark.kt
@@ -1,0 +1,73 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.coroutines.runBlocking
+import proj.memorchess.axl.core.graph.OpeningTree
+import proj.memorchess.axl.core.graph.TreeStore
+
+/**
+ * Measures opening graph construction and lookup through [TreeStore], the single mutation
+ * chokepoint production code uses, over a repertoire sized set of positions replayed from
+ * [OpeningLines].
+ *
+ * Guards against regressions in the immutable copy on write strategy of [OpeningTree]: every edge
+ * upsert rebuilds the affected nodes and replaces the internal map, so an accidental change from
+ * structural sharing to full copies would degrade quadratically with repertoire size and show up
+ * here long before users with large repertoires notice it.
+ */
+@State(Scope.Benchmark)
+class OpeningTreeBenchmark {
+
+  private var edges: List<OpeningLines.MoveEdge> = emptyList()
+
+  private var prebuiltTree: OpeningTree = OpeningTree()
+
+  @Setup
+  fun setup() {
+    edges = OpeningLines.replayToEdges()
+    prebuiltTree = buildStore().current()
+  }
+
+  /**
+   * Builds the whole graph from scratch, edge by edge, through [TreeStore.addMove] with classified
+   * moves, which includes the conversion of touched nodes to their persisted shape.
+   *
+   * Guards the cost of saving a repertoire sized batch of moves, the dominant operation of the
+   * initial load and of bulk imports.
+   */
+  @Benchmark
+  fun buildTreeFromEdges(bh: Blackhole) {
+    val store = buildStore()
+    bh.consume(store.current().snapshot().size)
+  }
+
+  /**
+   * Looks up every position of the prebuilt graph: node access, depth, membership, and the state
+   * computation the board coloring runs for the displayed position.
+   *
+   * Guards the read path executed on every navigation step in the explorer and the trainer.
+   */
+  @Benchmark
+  fun lookupEveryPosition(bh: Blackhole) {
+    for (edge in edges) {
+      bh.consume(prebuiltTree.get(edge.to))
+      bh.consume(prebuiltTree.getDepth(edge.to))
+      bh.consume(prebuiltTree.isKnown(edge.from))
+      bh.consume(prebuiltTree.computeState(edge.to, edge.from))
+    }
+  }
+
+  private fun buildStore(): TreeStore {
+    val store = TreeStore(NoOpDatabaseQueryManager())
+    runBlocking {
+      for (edge in edges) {
+        store.addMove(edge.from, edge.san, edge.to, isGood = true, fromDepth = edge.fromDepth)
+      }
+    }
+    return store
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,3 +52,5 @@ include(":composeApp")
 include(":androidApp")
 
 include(":macrobenchmark")
+
+include(":microbenchmark")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,3 +50,5 @@ dependencyResolutionManagement {
 include(":composeApp")
 
 include(":androidApp")
+
+include(":macrobenchmark")


### PR DESCRIPTION
Closes #159

## What

Two complementary performance harnesses plus the CI to run them:

1. **`:macrobenchmark`**: release grade UI benchmarks on Android (device, emulator, or the bundled Gradle Managed Device).
2. **`:microbenchmark`**: JVM microbenchmarks (kotlinx-benchmark / JMH) for the pure Kotlin core, catching algorithmic regressions with no device at all.

### Macrobenchmark

- New `:macrobenchmark` module (`com.android.test`, self instrumenting, benchmark variant only):
  - `ScreenNavigationBenchmark`: `FrameTimingMetric` while cycling Explore, Training, Settings through the bottom navigation bar. App startup excluded from the measured window.
  - `BoardCompositionBenchmark`: `TraceSectionMetric("%BoardGrid%", Sum)` measuring board composition when entering Explore from Settings.
- `androidApp` `benchmark` build type: `initWith(release)`, debug signing so it installs anywhere, `isDebuggable = false`, `<profileable android:shell="true"/>` via a benchmark only manifest overlay.
- `pixel6Api34` Gradle Managed Device.

### Microbenchmark

- JVM only module on kotlinx-benchmark 0.4.14 + Kotlin allopen for JMH `@State`; all versions and plugin aliases through `libs.versions.toml`. **Zero changes to composeApp**: the graph is built through the public `TreeStore` chokepoint with a no op `DatabaseQueryManager`.
- Benchmarks with deterministic fixtures (16 fixed opening lines, constant FSRS fuzz), each KDoc'd with the regression it guards:
  - `GameEngineBenchmark`: SAN move validation plus FEN production.
  - `OpeningTreeBenchmark`: repertoire sized graph construction and the lookup path (`get`, `getDepth`, `isKnown`, `computeState`).
  - `Fsrs6SchedulingBenchmark`: scheduling pass over 101 `CardState`s covering every `ReviewGrade` and `CardPhase`, short and long term paths.
  - `FenBenchmark`: cropped FEN parsing and position cropping.
- JSON reports; main config 3 warmups + 5 iterations of 500 ms, 1 fork, full suite ~36 s locally. Extra `mainSmokeBenchmark` config for fast sanity runs. ktfmt Google style; excluded from Sonar like `:macrobenchmark`.

### CI

- Reusable `benchmark-run.yml` (`workflow_call`): `macrobenchmark` job (KVM emulator) and `microbenchmark` job (plain JVM, no KVM) run **in parallel**; each uploads its own JSON, then a `merge-results` job combines them via `actions/upload-artifact/merge` into a single `benchmark-results` artifact with one subdirectory per module.
- `benchmark.yml`: daily 03:00 UTC cron on master plus manual dispatch. Master runs record a unified summary (macro + micro metrics with per metric direction) as one JSON on the orphan `benchmark-data` branch, pruned after 60 days. Manual dispatch on master records too (fast baseline seeding); other branches run without recording (`record_baseline` input to opt out).
- `benchmark-pr.yml`: opt in via the new "Run benchmarks" checkbox in the PR template. A cheap gate exits in seconds when unticked; when ticked, the same reusable suite runs and one sticky comment compares the results against the mean ± σ of the last 10 master baselines (thresholds: max(2σ, 1%) for emulator macrobenchmarks, max(2σ, 3%) for JVM microbenchmarks). Verdicts are advisory only, never blocking.
- `check.yml` keeps both modules compiling: cheap tier `compile-multiplat` and full tier `compile-benchmark` assemble `:macrobenchmark` and `:microbenchmark`. A `.kt` edit inside either module resolves to the cheap tier (covered by `compile-multiplat`); gradle or version catalog edits resolve to the full tier (covered by `compile-benchmark`).

### Docs

`macrobenchmark/README.md`, `microbenchmark/README.md` (incl. the caveat that JVM numbers are not ART numbers), and CLAUDE.md module list and build commands.

## Deviation from the issue

No `trace("BoardGridComposition")` marker and no `composeApp` change at all. Instead, `androidx.compose.runtime:runtime-tracing` is added to the **benchmark variant only** of `androidApp`, combined with `androidx.benchmark.fullTracing.enable=true` in the test module. The Compose compiler already emits trace events for every composable; this surfaces them as Perfetto slices that `TraceSectionMetric("%BoardGrid%")` aggregates. Verified the dep is absent from debug and release APKs. The version (1.11.2) must track the androidx runtime that Compose Multiplatform resolves to; a comment in `libs.versions.toml` documents this.

`MainActivity` enables `testTagsAsResourceId` so UiAutomator can target the existing `bottom_navigation_bar_item_*` test tags (content descriptions are localized, hence unreliable).

## Verified

- `ktfmtCheck` clean; `:macrobenchmark:assembleBenchmark`, `:androidApp:assembleBenchmark`, `assembleDebug`, `assembleDebugAndroidTest`, `:microbenchmark:assemble` all pass.
- Merged benchmark manifest contains `profileable`, no `debuggable`.
- Macro: not yet executed on a device (none attached). First run: `./gradlew :macrobenchmark:connectedBenchmarkAndroidTest` (see README for the emulator flag).
- Micro: full suite executed locally in 36 s, all 8 benchmarks pass (proves every fixture SAN line is legal), JSON report produced. Both workflow YAML files parse.

## Options

- [ ] Force running tests
- [x] Run benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
