### PR TITLE
test(perf): add JVM microbenchmark suite for core logic

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,8 @@
-name: UI performance benchmark
+name: Performance benchmarks
 
-# Manual trigger only: benchmarks take long, need an emulator, and their numbers on shared
-# CI hardware are only useful for relative comparisons, so they stay out of the PR checks.
+# Manual trigger only: benchmarks take long, the macro job needs an emulator, and their
+# numbers on shared CI hardware are only useful for relative comparisons, so they stay out
+# of the PR checks.
 on:
   workflow_dispatch:
 
@@ -55,4 +56,52 @@ jobs:
           path: |
             macrobenchmark/build/outputs/**/*.json
             macrobenchmark/build/outputs/**/*.perfetto-trace
+          retention-days: 30
+
+  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
+  # with the macrobenchmark job.
+  microbenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - name: Run JVM microbenchmarks
+        run: ./gradlew :microbenchmark:benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: microbenchmark-results
+          path: microbenchmark/build/reports/benchmarks/**/*.json
+          retention-days: 30
+
+  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
+  # final job merges their uploads into the single benchmark-results artifact consumers
+  # download. Each source artifact lands in its own subdirectory.
+  merge-results:
+    runs-on: ubuntu-latest
+    needs: [macrobenchmark, microbenchmark]
+    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
+    steps:
+      - name: Merge benchmark artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: benchmark-results
+          pattern: '{macrobenchmark,microbenchmark}-results'
+          separate-directories: true
+          delete-merged: true
           retention-days: 30

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -191,8 +191,8 @@ jobs:
           retention-days: 1
 
   # Cheap tier safety net: compile Android + wasm to catch expect/actual breaks, plus the
-  # macrobenchmark module, which no test job builds because its benchmarks only execute on
-  # the manually triggered benchmark workflow.
+  # macrobenchmark and microbenchmark modules, which no test job builds because their
+  # benchmarks only execute on the manually triggered benchmark workflow.
   compile-multiplat:
     needs: [detect]
     if: needs.detect.outputs.tier == 'cheap'
@@ -212,12 +212,12 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Compile Android + wasm targets and the macrobenchmark module
-        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark
+      - name: Compile Android + wasm targets and the benchmark modules
+        run: ./gradlew :androidApp:compileDebugKotlin compileKotlinWasmJs :macrobenchmark:assembleBenchmark :microbenchmark:assemble
 
-  # Full tier counterpart for the macrobenchmark module only: build config changes (gradle
+  # Full tier counterpart for the benchmark modules only: build config changes (gradle
   # files, version catalog) resolve to the full tier, where the test jobs compile every
-  # target except this one, so without this job a breaking version bump would pass CI.
+  # target except these, so without this job a breaking version bump would pass CI.
   compile-benchmark:
     needs: [detect]
     if: needs.detect.outputs.tier == 'full'
@@ -237,8 +237,8 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Assemble the macrobenchmark module
-        run: ./gradlew :macrobenchmark:assembleBenchmark
+      - name: Assemble the benchmark modules
+        run: ./gradlew :macrobenchmark:assembleBenchmark :microbenchmark:assemble
 
   # Full tier: Android instrumented tests, sharded across emulators
   android-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,15 +28,19 @@ MemorChess (Anki Chess) is a Kotlin Multiplatform app for memorizing chess openi
 
 # UI performance benchmarks (Android device/emulator only, see macrobenchmark/README.md)
 ./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
+
+# Core logic microbenchmarks (plain JVM, see microbenchmark/README.md)
+./gradlew :microbenchmark:benchmark
 ```
 
 ## Architecture
 
-Three Gradle modules:
+Four Gradle modules:
 
 - **`composeApp`** is the Kotlin Multiplatform library holding all shared code. Its Android target uses the `com.android.kotlin.multiplatform.library` plugin (`kotlin.androidLibrary {}` DSL, no `android {}` block). Source sets: `commonMain`, `androidMain` (platform actuals, OAuth redirect activity, `AndroidContextProvider`), `jvmMain`, `iosMain`, `wasmJsMain`, `nonJsMain` (Room DB shared by Android/JVM/iOS), `debugMain` (hot-reload previews).
 - **`androidApp`** is the thin Android application shell: `MainActivity` (initializes `AndroidContextProvider` and FileKit), launcher manifest and resources, and the instrumented tests (`src/androidTest`). It applies `com.android.application` and relies on the Kotlin support built into AGP 9. Besides `debug` and `release` it has a `benchmark` build type (release performance, debug signing, profileable) measured by `:macrobenchmark`.
 - **`macrobenchmark`** is a `com.android.test` module holding UI performance benchmarks (`FrameTimingMetric`, `TraceSectionMetric` via Compose composition tracing) that run against the `benchmark` build of `androidApp` on a device or emulator. See `macrobenchmark/README.md`.
+- **`microbenchmark`** is a JVM only kotlinx-benchmark (JMH) module measuring the pure Kotlin core of `composeApp` (`GameEngine`, `OpeningTree`/`TreeStore`, `Fsrs6SchedulingAlgorithm`, FEN handling) with deterministic fixtures. It catches algorithmic regressions only; JVM numbers are not ART numbers. See `microbenchmark/README.md`.
 
 The AGP version is capped below 9.1 (renovate rule) because IntelliJ IDEA only syncs AGP versions its Android plugin supports.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
   alias(libs.plugins.composeMultiplatform) apply false
   alias(libs.plugins.composeCompiler) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false
+  alias(libs.plugins.kotlinJvm) apply false
+  alias(libs.plugins.kotlinAllopen) apply false
+  alias(libs.plugins.kotlinxBenchmark) apply false
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.composeHotReload) apply false
   alias(libs.plugins.sonar)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ kover = "0.9.8"
 koin = "4.2.1"
 ktfmt = "0.26.0"
 kotlin = "2.4.0"
+kotlinx-benchmark = "0.4.14"
+kotlinx-coroutines = "1.10.2"
 ksp = "2.3.9"
 kotest = "6.1.11"
 kotlinxDatetime = "0.8.0"
@@ -92,6 +94,8 @@ koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-view
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 androidx-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
@@ -124,7 +128,10 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktfmt = {id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt"}
+kotlinAllopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinxBenchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 kotlinX-serialization-plugin = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 room = { id = "androidx.room", version.ref = "androidx-room" }

--- a/microbenchmark/README.md
+++ b/microbenchmark/README.md
@@ -1,0 +1,54 @@
+# Microbenchmark
+
+JVM microbenchmarks for the pure Kotlin core of `:composeApp`, built on
+[kotlinx-benchmark](https://github.com/Kotlin/kotlinx-benchmark) (JMH under the hood). They
+complement `:macrobenchmark`: that module measures the rendered Android UI, this one measures the
+algorithms underneath it, with no device or emulator required.
+
+## What is measured
+
+| Benchmark                  | What it guards                                                                                          |
+|----------------------------|---------------------------------------------------------------------------------------------------------|
+| `GameEngineBenchmark`      | SAN move validation and FEN production while replaying opening lines, the per move hot path of the app. |
+| `OpeningTreeBenchmark`     | Building the opening graph through `TreeStore` and the lookup path used on every navigation step.       |
+| `Fsrs6SchedulingBenchmark` | A full FSRS 6 scheduling pass over a card batch covering every `ReviewGrade` and `CardPhase`.            |
+| `FenBenchmark`             | Parsing cropped FENs into engines and cropping positions back into `PositionKey`s.                       |
+
+All inputs are deterministic fixtures (`OpeningLines`); the FSRS fuzz source is a constant. Runs
+are therefore comparable across machines, up to hardware differences.
+
+## Running locally
+
+```sh
+./gradlew :microbenchmark:benchmark
+```
+
+The full suite takes a few minutes. For a quick check that every benchmark still executes (numbers
+are meaningless at these settings):
+
+```sh
+./gradlew :microbenchmark:mainSmokeBenchmark
+```
+
+## Reading the output
+
+JMH reports throughput in `ops/s`: one op is one whole benchmark method invocation, for example
+replaying all sixteen fixture lines, not a single move. Higher is better. The console prints a
+summary table; machine readable JSON lands under
+`microbenchmark/build/reports/benchmarks/<configuration>/<timestamp>/main.json` with `score`,
+`scoreError` and percentile fields per benchmark. Compare the `score` of the same benchmark across
+runs and treat differences within `scoreError` as noise.
+
+## Caveat: JVM numbers are not Android numbers
+
+These benchmarks run on a desktop JVM (HotSpot with C2). The app ships on ART, a different runtime
+with a different compiler, allocator and GC. Absolute values do not transfer. What does transfer is
+algorithmic complexity: a change that makes graph construction quadratic or doubles the work per
+SAN move shows up here regardless of runtime. Use this module to catch algorithmic regressions in
+core logic; use `:macrobenchmark` for realistic on device UI performance.
+
+## CI
+
+The manually triggered `benchmark.yml` workflow runs this suite in a `microbenchmark` job, in
+parallel with the `macrobenchmark` job, then merges both JSON result sets into a single
+`benchmark-results` artifact with one subdirectory per module.

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -1,0 +1,73 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.kotlinxBenchmark)
+  alias(libs.plugins.kotlinAllopen)
+  alias(libs.plugins.ktfmt)
+}
+
+// JMH requires benchmark state classes to be open; the Kotlin allopen plugin lifts the
+// restriction for every class annotated with JMH's @State.
+allOpen { annotation("org.openjdk.jmh.annotations.State") }
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_21)
+    // Edge and CardState expose kotlin.time.Instant in their public API.
+    optIn.add("kotlin.time.ExperimentalTime")
+  }
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_21
+  targetCompatibility = JavaVersion.VERSION_21
+}
+
+benchmark {
+  targets { register("main") }
+
+  configurations {
+    named("main") {
+      // Small but stable run: enough iterations for JMH to settle on the hot path while
+      // keeping the whole suite well under ten minutes.
+      warmups = 3
+      iterations = 5
+      iterationTime = 500
+      iterationTimeUnit = "ms"
+      // JSON keeps the results machine readable so CI can merge them with the
+      // macrobenchmark output into a single artifact.
+      reportFormat = "json"
+      advanced("jvmForks", "1")
+    }
+
+    // Minimal run proving every benchmark still executes; numbers are meaningless.
+    register("smoke") {
+      warmups = 1
+      iterations = 1
+      iterationTime = 100
+      iterationTimeUnit = "ms"
+      reportFormat = "json"
+      advanced("jvmForks", "1")
+    }
+  }
+}
+
+ktfmt { googleStyle() }
+
+// Benchmarks are not application code: keep them out of the Sonar analysis. Empty values
+// also stop the root configuration, which lists composeApp source sets that do not exist
+// here, from being inherited.
+extensions.configure<org.sonarqube.gradle.SonarExtension> {
+  properties {
+    property("sonar.sources", "")
+    property("sonar.tests", "")
+  }
+}
+
+dependencies {
+  implementation(projects.composeApp)
+  implementation(libs.kotlinx.benchmark.runtime)
+  // TreeStore's mutation API is suspending; benchmarks bridge it with runBlocking.
+  implementation(libs.kotlinx.coroutines.core)
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/FenBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/FenBenchmark.kt
@@ -1,0 +1,60 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Measures the conversions between board state and the FEN derived string forms: parsing a cropped
+ * FEN back into a [GameEngine] and cropping a live position down to a [PositionKey].
+ *
+ * Guards against regressions in position identity handling. Every persisted node is keyed by its
+ * cropped FEN, so parsing runs for each node when entering a stored position and cropping runs
+ * after every move; both are also the backbone of database loading.
+ */
+@State(Scope.Benchmark)
+class FenBenchmark {
+
+  private var positionKeys: List<PositionKey> = emptyList()
+
+  private var engines: List<GameEngine> = emptyList()
+
+  @Setup
+  fun setup() {
+    val edges = OpeningLines.replayToEdges()
+    positionKeys =
+      (listOf(PositionKey.START_POSITION) + edges.map { it.to }).distinctBy { it.value }
+    engines = positionKeys.map { GameEngine(it) }
+  }
+
+  /**
+   * Rebuilds a [GameEngine] from every distinct cropped FEN of the fixture graph.
+   *
+   * Guards the cropped FEN completion and board parsing cost paid for every position opened from
+   * the database, for example when a training card is shown.
+   */
+  @Benchmark
+  fun parseCroppedFens(bh: Blackhole) {
+    for (key in positionKeys) {
+      bh.consume(GameEngine(key).toFen())
+    }
+  }
+
+  /**
+   * Produces the [PositionKey] and the full FEN of every prebuilt position.
+   *
+   * Guards the FEN cropping path, including the en passant relevance check, which runs after every
+   * move played anywhere in the app.
+   */
+  @Benchmark
+  fun cropPositionsToKeys(bh: Blackhole) {
+    for (engine in engines) {
+      bh.consume(engine.toPositionKey())
+      bh.consume(engine.toFen())
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/Fsrs6SchedulingBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/Fsrs6SchedulingBenchmark.kt
@@ -1,0 +1,87 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.scheduling.CardPhase
+import proj.memorchess.axl.core.scheduling.CardState
+import proj.memorchess.axl.core.scheduling.Fsrs6SchedulingAlgorithm
+import proj.memorchess.axl.core.scheduling.ReviewGrade
+
+/**
+ * Measures a full [Fsrs6SchedulingAlgorithm] scheduling pass over a deterministic batch of
+ * [CardState] values covering every [ReviewGrade], every [CardPhase], and a first review.
+ *
+ * Guards against regressions in the FSRS math (forgetting curve, stability and difficulty updates,
+ * interval fuzz). The trainer schedules every reviewed position synchronously on the UI thread, so
+ * a slowdown here directly delays the next card after each answer. The fuzz source is a constant so
+ * results never depend on randomness.
+ */
+@State(Scope.Benchmark)
+class Fsrs6SchedulingBenchmark {
+
+  private val now: Instant = Instant.parse("2026-01-01T00:00:00Z")
+
+  /** Short term scheduler with the learning step ladders active, the app's default mode. */
+  private val shortTermAlgorithm =
+    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 }, enableShortTerm = { true })
+
+  /** Long term only scheduler, the mode used when the user disables learning steps. */
+  private val longTermAlgorithm =
+    Fsrs6SchedulingAlgorithm(enableFuzz = { true }, nextFuzz = { 0.5 }, enableShortTerm = { false })
+
+  private var cards: List<CardState?> = emptyList()
+
+  @Setup
+  fun setup() {
+    // One null entry exercises the first review path; the rest sweep phases, learning steps,
+    // elapsed times, stabilities and difficulties with fixed arithmetic progressions.
+    cards =
+      listOf(null) +
+        (0 until 100).map { i ->
+          CardState(
+            dueDate = now,
+            lastReview = now - ((i % 30) + 1).days,
+            stability = 0.4 + i * 0.37,
+            difficulty = 1.0 + (i % 91) / 10.0,
+            reps = i,
+            lapses = i % 5,
+            phase = CardPhase.entries[i % CardPhase.entries.size],
+            step = i % 2,
+          )
+        }
+  }
+
+  /**
+   * Schedules every card of the batch with all four grades through the short term state machine.
+   *
+   * Guards the learning and relearning routing on top of the core FSRS math.
+   */
+  @Benchmark
+  fun shortTermSchedulingPass(bh: Blackhole) {
+    for (card in cards) {
+      for (grade in ReviewGrade.entries) {
+        bh.consume(shortTermAlgorithm.schedule(card, grade, now))
+      }
+    }
+  }
+
+  /**
+   * Schedules every card of the batch with all four grades through the long term path, which
+   * computes candidate intervals for all grades and enforces their monotonic ordering.
+   *
+   * Guards the heavier all grades candidate computation of the long term scheduler.
+   */
+  @Benchmark
+  fun longTermSchedulingPass(bh: Blackhole) {
+    for (card in cards) {
+      for (grade in ReviewGrade.entries) {
+        bh.consume(longTermAlgorithm.schedule(card, grade, now))
+      }
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/GameEngineBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/GameEngineBenchmark.kt
@@ -1,0 +1,54 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.State
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Measures [GameEngine] on the hot path of both exploration and training: validating and applying
+ * SAN moves, then producing the position identity used to key the opening graph.
+ *
+ * Guards against regressions in move validation and FEN production, the two operations executed on
+ * every single move a user plays. A slowdown here multiplies across the whole app because every
+ * interaction controller funnels moves through [GameEngine].
+ */
+@State(Scope.Benchmark)
+class GameEngineBenchmark {
+
+  /**
+   * Plays all fixture lines move by move from the starting position and reads the final FEN.
+   *
+   * Guards the SAN parsing and legal move generation cost of [GameEngine.playSanMove], the exact
+   * work done when replaying stored lines.
+   */
+  @Benchmark
+  fun playSanLines(bh: Blackhole) {
+    for (line in OpeningLines.SAN_LINES) {
+      val engine = GameEngine()
+      for (san in line) {
+        engine.playSanMove(san)
+      }
+      bh.consume(engine.toFen())
+    }
+  }
+
+  /**
+   * Plays all fixture lines and derives a [proj.memorchess.axl.core.data.PositionKey] after every
+   * ply, exactly as the explorer does to look up each reached position in the opening graph.
+   *
+   * Guards the combined cost of move application plus FEN cropping, including the en passant
+   * relevance check.
+   */
+  @Benchmark
+  fun positionKeyAfterEveryMove(bh: Blackhole) {
+    for (line in OpeningLines.SAN_LINES) {
+      val engine = GameEngine()
+      for (san in line) {
+        engine.playSanMove(san)
+        bh.consume(engine.toPositionKey())
+      }
+    }
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
@@ -1,0 +1,31 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlin.time.Instant
+import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.DatabaseQueryManager
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.graph.DeleteMode
+
+/**
+ * [DatabaseQueryManager] that persists nothing.
+ *
+ * Benchmarks plug it into [proj.memorchess.axl.core.graph.TreeStore] so that graph mutation
+ * measurements cover the full store logic, including the conversion of nodes to their persisted
+ * shape, without any platform database I/O skewing the numbers.
+ */
+class NoOpDatabaseQueryManager : DatabaseQueryManager {
+
+  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> = emptyList()
+
+  override suspend fun getPosition(positionKey: PositionKey): DataNode? = null
+
+  override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) = Unit
+
+  override suspend fun deleteMove(origin: PositionKey, move: String, mode: DeleteMode) = Unit
+
+  override suspend fun eraseAll() = Unit
+
+  override suspend fun insertNodes(vararg positions: DataNode) = Unit
+
+  override suspend fun getLastUpdate(): Instant? = null
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningLines.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningLines.kt
@@ -1,0 +1,88 @@
+package proj.memorchess.axl.microbenchmark
+
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.engine.GameEngine
+
+/**
+ * Deterministic benchmark fixture: sixteen well known opening main lines, twenty plies each, given
+ * in marker free SAN exactly as the app stores moves.
+ *
+ * The fixture is the single source of inputs for every benchmark in this module so that runs stay
+ * comparable across machines and over time. Changing a line invalidates historical comparisons; add
+ * new lines instead of editing existing ones.
+ */
+object OpeningLines {
+
+  /** One entry per opening, each a sequence of SAN moves playable from the starting position. */
+  val SAN_LINES: List<List<String>> =
+    listOf(
+        // Ruy Lopez, Breyer
+        "e4 e5 Nf3 Nc6 Bb5 a6 Ba4 Nf6 O-O Be7 Re1 b5 Bb3 d6 c3 O-O h3 Nb8 d4 Nbd7",
+        // Italian, Giuoco Pianissimo
+        "e4 e5 Nf3 Nc6 Bc4 Bc5 c3 Nf6 d3 d6 O-O a6 a4 Ba7 Re1 O-O h3 Be6 Bxe6 fxe6",
+        // Sicilian, Najdorf English Attack
+        "e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 Be3 e5 Nb3 Be6 f3 Be7 Qd2 O-O O-O-O Nbd7",
+        // Sicilian, Sveshnikov
+        "e4 c5 Nf3 Nc6 d4 cxd4 Nxd4 Nf6 Nc3 e5 Ndb5 d6 Bg5 a6 Na3 b5 Nd5 Be7 Bxf6 Bxf6",
+        // French, Winawer poisoned pawn
+        "e4 e6 d4 d5 Nc3 Bb4 e5 c5 a3 Bxc3 bxc3 Ne7 Qg4 Qc7 Qxg7 Rg8 Qxh7 cxd4 Ne2 Nbc6",
+        // Caro Kann, Classical
+        "e4 c6 d4 d5 Nc3 dxe4 Nxe4 Bf5 Ng3 Bg6 h4 h6 Nf3 Nd7 h5 Bh7 Bd3 Bxd3 Qxd3 e6",
+        // Queen's Gambit Declined, Tartakower
+        "d4 d5 c4 e6 Nc3 Nf6 Bg5 Be7 e3 O-O Nf3 h6 Bh4 b6 Be2 Bb7 Bxf6 Bxf6 cxd5 exd5",
+        // Slav, Czech main line
+        "d4 d5 c4 c6 Nf3 Nf6 Nc3 dxc4 a4 Bf5 e3 e6 Bxc4 Bb4 O-O O-O Qe2 Nbd7",
+        // King's Indian, Classical
+        "d4 Nf6 c4 g6 Nc3 Bg7 e4 d6 Nf3 O-O Be2 e5 O-O Nc6 d5 Ne7 Ne1 Nd7 Be3 f5",
+        // Nimzo Indian, Rubinstein
+        "d4 Nf6 c4 e6 Nc3 Bb4 e3 O-O Bd3 d5 Nf3 c5 O-O Nc6 a3 Bxc3 bxc3 dxc4 Bxc4 Qc7",
+        // Gruenfeld, Exchange
+        "d4 Nf6 c4 g6 Nc3 d5 cxd5 Nxd5 e4 Nxc3 bxc3 Bg7 Nf3 c5 Rb1 O-O Be2 cxd4 cxd4 Qa5",
+        // English, Four Knights reversed dragon
+        "c4 e5 Nc3 Nf6 Nf3 Nc6 g3 d5 cxd5 Nxd5 Bg2 Nb6 O-O Be7 d3 O-O a3 Be6 b4 a5",
+        // London System
+        "d4 d5 Bf4 Nf6 e3 c5 Nf3 Nc6 c3 e6 Nbd2 Bd6 Bg3 O-O Bd3 b6 e4 dxe4 Nxe4 Be7",
+        // Scotch, Mieses
+        "e4 e5 Nf3 Nc6 d4 exd4 Nxd4 Nf6 Nxc6 bxc6 e5 Qe7 Qe2 Nd5 c4 Ba6 b3 g6 g3 Bg7",
+        // Catalan, Open
+        "d4 Nf6 c4 e6 g3 d5 Bg2 Be7 Nf3 O-O O-O dxc4 Qc2 a6 Qxc4 b5 Qc2 Bb7 Bd2 Be4",
+        // Petroff, Classical
+        "e4 e5 Nf3 Nf6 Nxe5 d6 Nf3 Nxe4 d4 d5 Bd3 Nc6 O-O Be7 c4 Nb4 Be2 O-O Nc3 Bf5",
+      )
+      .map { it.split(" ") }
+
+  /**
+   * One graph edge produced by replaying the fixture lines.
+   *
+   * @property from Position the move is played from.
+   * @property san The move in marker free SAN.
+   * @property to Position reached after the move.
+   * @property fromDepth Ply distance of [from] from the starting position.
+   */
+  data class MoveEdge(
+    val from: PositionKey,
+    val san: String,
+    val to: PositionKey,
+    val fromDepth: Int,
+  )
+
+  /**
+   * Replays every line through [GameEngine] and returns the deduplicated edge list, in first
+   * occurrence order. Lines share their early plies, so the result is a tree shaped graph of a few
+   * hundred positions, the realistic size of a personal opening repertoire.
+   */
+  fun replayToEdges(): List<MoveEdge> {
+    val edges = LinkedHashMap<Pair<PositionKey, String>, MoveEdge>()
+    for (line in SAN_LINES) {
+      val engine = GameEngine()
+      var fromKey = engine.toPositionKey()
+      line.forEachIndexed { ply, san ->
+        engine.playSanMove(san)
+        val toKey = engine.toPositionKey()
+        edges.getOrPut(fromKey to san) { MoveEdge(fromKey, san, toKey, ply) }
+        fromKey = toKey
+      }
+    }
+    return edges.values.toList()
+  }
+}

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningTreeBenchmark.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/OpeningTreeBenchmark.kt
@@ -1,0 +1,73 @@
+package proj.memorchess.axl.microbenchmark
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Blackhole
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.coroutines.runBlocking
+import proj.memorchess.axl.core.graph.OpeningTree
+import proj.memorchess.axl.core.graph.TreeStore
+
+/**
+ * Measures opening graph construction and lookup through [TreeStore], the single mutation
+ * chokepoint production code uses, over a repertoire sized set of positions replayed from
+ * [OpeningLines].
+ *
+ * Guards against regressions in the immutable copy on write strategy of [OpeningTree]: every edge
+ * upsert rebuilds the affected nodes and replaces the internal map, so an accidental change from
+ * structural sharing to full copies would degrade quadratically with repertoire size and show up
+ * here long before users with large repertoires notice it.
+ */
+@State(Scope.Benchmark)
+class OpeningTreeBenchmark {
+
+  private var edges: List<OpeningLines.MoveEdge> = emptyList()
+
+  private var prebuiltTree: OpeningTree = OpeningTree()
+
+  @Setup
+  fun setup() {
+    edges = OpeningLines.replayToEdges()
+    prebuiltTree = buildStore().current()
+  }
+
+  /**
+   * Builds the whole graph from scratch, edge by edge, through [TreeStore.addMove] with classified
+   * moves, which includes the conversion of touched nodes to their persisted shape.
+   *
+   * Guards the cost of saving a repertoire sized batch of moves, the dominant operation of the
+   * initial load and of bulk imports.
+   */
+  @Benchmark
+  fun buildTreeFromEdges(bh: Blackhole) {
+    val store = buildStore()
+    bh.consume(store.current().snapshot().size)
+  }
+
+  /**
+   * Looks up every position of the prebuilt graph: node access, depth, membership, and the state
+   * computation the board coloring runs for the displayed position.
+   *
+   * Guards the read path executed on every navigation step in the explorer and the trainer.
+   */
+  @Benchmark
+  fun lookupEveryPosition(bh: Blackhole) {
+    for (edge in edges) {
+      bh.consume(prebuiltTree.get(edge.to))
+      bh.consume(prebuiltTree.getDepth(edge.to))
+      bh.consume(prebuiltTree.isKnown(edge.from))
+      bh.consume(prebuiltTree.computeState(edge.to, edge.from))
+    }
+  }
+
+  private fun buildStore(): TreeStore {
+    val store = TreeStore(NoOpDatabaseQueryManager())
+    runBlocking {
+      for (edge in edges) {
+        store.addMove(edge.from, edge.san, edge.to, isGood = true, fromDepth = edge.fromDepth)
+      }
+    }
+    return store
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,3 +52,5 @@ include(":composeApp")
 include(":androidApp")
 
 include(":macrobenchmark")
+
+include(":microbenchmark")


### PR DESCRIPTION
Stacked on #193 (uses its `benchmark.yml` and the tiered compile jobs).

## What

New `:microbenchmark` Gradle module built on kotlinx-benchmark 0.4.14 (JMH on the JVM) measuring the pure Kotlin core of `:composeApp`, with **zero changes to composeApp**.

### Benchmarks (deterministic fixtures, no randomness)

- `GameEngineBenchmark`: SAN move validation plus FEN production while replaying 16 fixed opening main lines.
- `OpeningTreeBenchmark`: graph construction through `TreeStore` (the public mutation chokepoint, since `OpeningTree` mutators are internal) backed by a no op `DatabaseQueryManager`, plus the lookup path (`get`, `getDepth`, `isKnown`, `computeState`).
- `Fsrs6SchedulingBenchmark`: scheduling pass over 101 `CardState` values covering every `ReviewGrade`, every `CardPhase` and a first review, on both the short term and long term paths, with a constant fuzz source.
- `FenBenchmark`: cropped FEN parsing into `GameEngine` and position cropping back to `PositionKey`.

Every benchmark carries KDoc stating the regression it guards against.

### Module setup

- JVM only, `org.jetbrains.kotlinx.benchmark` + Kotlin allopen on `org.openjdk.jmh.annotations.State`, all versions and aliases through `libs.versions.toml`, `apply false` in the root build.
- JSON reports (`reportFormat = "json"`); main config is 3 warmups + 5 iterations of 500 ms, 1 fork. Full suite measured locally: **36 s**.
- Extra `smoke` configuration (`mainSmokeBenchmark`) for fast verification that the suite executes.
- ktfmt Google style (the plugin picks up Kotlin/JVM source sets natively, no manual wiring needed) and the same empty `sonar.sources` exclusion as `:macrobenchmark`.

### CI

- `benchmark.yml`: new `microbenchmark` job (plain JVM, no KVM) running in parallel with `macrobenchmark`; both upload their own JSON artifact and a final `merge-results` job combines them via `actions/upload-artifact/merge` into a single `benchmark-results` artifact with one subdirectory per module. `workflow_dispatch` unchanged.
- `check.yml`: `:microbenchmark:assemble` added to the existing cheap tier `compile-multiplat` and full tier `compile-benchmark` jobs. Tier coverage: a `.kt` edit inside `microbenchmark/` matches the `code` filter only, resolving to the cheap tier where `compile-multiplat` builds it; `microbenchmark/build.gradle.kts` and `libs.versions.toml` edits match the `platform` filter, resolving to the full tier where `compile-benchmark` builds it. Nothing left uncovered.

### Docs

`microbenchmark/README.md` (what is measured, how to run, how to read JMH output, JVM vs ART caveat) and CLAUDE.md module list and build commands.

## Verification

- `./gradlew ktfmtFormat` clean
- `./gradlew :microbenchmark:mainSmokeBenchmark` all 8 benchmarks execute (proves all fixture SAN lines are legal)
- `./gradlew :microbenchmark:benchmark` full suite passes in 36 s, JSON report produced
- `./gradlew :microbenchmark:assemble` passes
- Both workflow YAML files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)