### PR TITLE
ci(benchmark): add baseline pipeline with PR comparison

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
 ## Options
 
 - [ ] Force running tests
+- [ ] Run benchmarks

--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -1,0 +1,201 @@
+"""
+Compares a PR benchmark summary against the master baseline window and renders
+the result as a markdown comment.
+
+The baseline is the N most recent summary files (produced by
+extract_benchmark_summary.py) on the benchmark-data branch. For every metric in
+the PR summary the script computes the baseline mean and sample standard
+deviation, then classifies the PR value:
+
+- UI macrobenchmarks run on an emulator and are noisy, so the threshold is
+  max(2 sigma, 1% of the mean); the 1% floor avoids flagging everything when
+  all baseline values happen to be identical (sigma = 0).
+- JVM microbenchmarks are far tighter, so a plain 2 sigma band would flag
+  ordinary runner variance; the threshold is max(2 sigma, 3% of the mean).
+
+The verdict is advisory only: the comment never blocks a merge. The first line
+of the output is an HTML marker so the calling workflow can find and update the
+existing comment instead of stacking new ones.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+COMMENT_MARKER = "<!-- benchmark-comparison -->"
+
+# Minimum baseline entries containing a metric before a verdict is attempted.
+MIN_BASELINE_SAMPLES = 3
+
+SIGMA_MULTIPLIER = 2.0
+MACRO_RELATIVE_FLOOR = 0.01
+MICRO_RELATIVE_FLOOR = 0.03
+
+VERDICT_WITHIN = "✅ within noise"
+VERDICT_REGRESSION = "⚠️ regression"
+VERDICT_IMPROVEMENT = "🟢 improvement"
+VERDICT_NO_BASELINE = "➖ no baseline"
+
+
+def load_baselines(baseline_dir: Path, window: int) -> List[dict]:
+    """Loads the most recent baseline summaries, newest first by filename."""
+    baselines = []
+    for path in sorted(baseline_dir.glob("*.json"), reverse=True)[:window]:
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(data, dict) and "metrics" in data:
+            baselines.append(data)
+    return baselines
+
+
+def format_value(value: float) -> str:
+    """Formats with enough precision for small ms values and large ops/s ones."""
+    if value == 0:
+        return "0"
+    if abs(value) >= 1000:
+        return f"{value:,.0f}"
+    if abs(value) >= 1:
+        return f"{value:.2f}"
+    return f"{value:.4f}"
+
+
+def relative_floor(key: str) -> float:
+    return MACRO_RELATIVE_FLOOR if key.startswith("macro/") else MICRO_RELATIVE_FLOOR
+
+
+def classify(key: str, entry: dict, values: List[float]) -> dict:
+    """Builds one comparison row for a metric present in the PR summary."""
+    pr_value = entry["value"]
+    if len(values) < MIN_BASELINE_SAMPLES:
+        return {
+            "pr": format_value(pr_value),
+            "baseline": f"n={len(values)}",
+            "delta": "n/a",
+            "verdict": VERDICT_NO_BASELINE,
+        }
+
+    mean = statistics.mean(values)
+    sigma = statistics.stdev(values)
+    threshold = max(SIGMA_MULTIPLIER * sigma, relative_floor(key) * abs(mean))
+    delta = pr_value - mean
+
+    if mean != 0:
+        delta_text = f"{delta / abs(mean) * 100:+.1f}%"
+    else:
+        delta_text = f"{delta:+g} (abs)"
+
+    if abs(delta) <= threshold:
+        verdict = VERDICT_WITHIN
+    else:
+        worse = delta > 0 if entry["direction"] == "lower" else delta < 0
+        verdict = VERDICT_REGRESSION if worse else VERDICT_IMPROVEMENT
+
+    return {
+        "pr": format_value(pr_value),
+        "baseline": f"{format_value(mean)} ±{format_value(sigma)} (n={len(values)})",
+        "delta": delta_text,
+        "verdict": verdict,
+    }
+
+
+def render_section(
+    title: str,
+    note: str,
+    prefix: str,
+    pr_metrics: Dict[str, dict],
+    baselines: List[dict],
+) -> List[str]:
+    keys = sorted(k for k in pr_metrics if k.startswith(prefix))
+    if not keys:
+        return []
+    lines = [f"### {title}", "", note, ""]
+    lines.append("| Benchmark | Metric | PR | master | Δ | Verdict |")
+    lines.append("|---|---|---|---|---|---|")
+    for key in keys:
+        entry = pr_metrics[key]
+        values = [
+            b["metrics"][key]["value"] for b in baselines if key in b["metrics"]
+        ]
+        row = classify(key, entry, values)
+        benchmark, metric = split_key(key)
+        unit = f" {entry['unit']}" if entry.get("unit") else ""
+        lines.append(
+            f"| {benchmark} | {metric}{unit} | {row['pr']} | {row['baseline']} "
+            f"| {row['delta']} | {row['verdict']} |"
+        )
+    lines.append("")
+    return lines
+
+
+def split_key(key: str) -> tuple:
+    """Splits a metric key into its benchmark and metric display columns."""
+    parts = key.split("/")
+    if len(parts) == 3:
+        return parts[1], parts[2]
+    return parts[1], "score"
+
+
+def render_comment(
+    pr_summary: dict, baselines: List[dict], run_url: Optional[str]
+) -> str:
+    lines = [COMMENT_MARKER, "## Benchmark comparison", ""]
+    if not baselines:
+        lines.append(
+            "No master baseline data is available yet, so this run only reports "
+            "the PR's own numbers. Baselines accumulate from the daily master "
+            "benchmark run."
+        )
+        lines.append("")
+    lines += render_section(
+        "UI benchmarks (emulator)",
+        "Emulator numbers are noisy; only shifts beyond max(2σ, 1%) of the "
+        "master baseline are flagged.",
+        "macro/",
+        pr_summary["metrics"],
+        baselines,
+    )
+    lines += render_section(
+        "Core microbenchmarks (JVM)",
+        "Shifts beyond max(2σ, 3%) of the master baseline are flagged. "
+        "Throughput scores: higher is better.",
+        "micro/",
+        pr_summary["metrics"],
+        baselines,
+    )
+    lines.append(
+        f"_Advisory only, never blocking. Baseline: {len(baselines)} most recent "
+        "master runs from the `benchmark-data` branch._"
+    )
+    if run_url:
+        lines.append(f"_Raw results: [workflow run]({run_url})._")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-summary", type=Path, required=True)
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--window", type=int, default=10)
+    parser.add_argument("--run-url", default=None)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    pr_summary = json.loads(args.pr_summary.read_text())
+    baselines = (
+        load_baselines(args.baseline_dir, args.window)
+        if args.baseline_dir.is_dir()
+        else []
+    )
+
+    args.output.write_text(render_comment(pr_summary, baselines, args.run_url))
+    print(f"Wrote comparison against {len(baselines)} baseline runs to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/extract_benchmark_summary.py
+++ b/.github/scripts/extract_benchmark_summary.py
@@ -1,0 +1,160 @@
+"""
+Extracts a unified benchmark summary from the merged benchmark-results artifact.
+
+The artifact contains two kinds of result files:
+- Macrobenchmark `benchmarkData.json` files (an object with a `benchmarks` list,
+  each entry holding `metrics` with min/median/max and `sampledMetrics` with
+  percentile distributions). All macro metrics measure time, so lower is better.
+- kotlinx-benchmark / JMH JSON reports (a list of objects with `benchmark`,
+  `mode` and `primaryMetric`). Direction depends on the JMH mode: throughput
+  means higher is better, all time-based modes mean lower is better.
+
+Both are flattened into a single `metrics` map keyed by a stable string
+(`macro/<Class>.<method>/<metric>` or `micro/<Class>.<method>`), each entry
+carrying its value, unit and direction so the comparison script needs no
+knowledge of either source format.
+
+The optional `--prune-dir/--prune-days` pair deletes baseline files whose
+filename date prefix (YYYY-MM-DDTHH-MM) is older than the cutoff, keeping the
+baseline branch bounded.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+SCHEMA_VERSION = 1
+
+# Percentiles kept from Macrobenchmark sampled metrics (e.g. frameDurationCpuMs).
+SAMPLED_PERCENTILES = ("P50", "P90", "P99")
+
+# JMH modes where a higher score is better; every other mode measures time.
+HIGHER_IS_BETTER_MODES = {"thrpt", "Throughput"}
+
+
+def short_name(fully_qualified: str) -> str:
+    """Keeps only the last two dot-separated segments (Class.method)."""
+    return ".".join(fully_qualified.split(".")[-2:])
+
+
+def collect_macro_metrics(macro_dir: Path) -> Dict[str, dict]:
+    """Parses every Macrobenchmark JSON file found under the given directory."""
+    metrics: Dict[str, dict] = {}
+    for path in sorted(macro_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict) or "benchmarks" not in data:
+            continue
+        for benchmark in data["benchmarks"]:
+            simple_class = benchmark.get("className", "").split(".")[-1]
+            bench_key = f"{simple_class}.{benchmark.get('name', '')}"
+            for metric_name, stats in benchmark.get("metrics", {}).items():
+                if "median" not in stats:
+                    continue
+                key = f"macro/{bench_key}/{metric_name}_median"
+                metrics[key] = make_macro_entry(metric_name, stats["median"])
+            for metric_name, stats in benchmark.get("sampledMetrics", {}).items():
+                for percentile in SAMPLED_PERCENTILES:
+                    if percentile not in stats:
+                        continue
+                    key = f"macro/{bench_key}/{metric_name}_{percentile}"
+                    metrics[key] = make_macro_entry(metric_name, stats[percentile])
+    return metrics
+
+
+def make_macro_entry(metric_name: str, value: float) -> dict:
+    unit = "ms" if metric_name.endswith("Ms") else ""
+    return {"value": value, "unit": unit, "direction": "lower"}
+
+
+def collect_micro_metrics(micro_dir: Path) -> Dict[str, dict]:
+    """Parses every JMH JSON report found under the given directory."""
+    metrics: Dict[str, dict] = {}
+    for path in sorted(micro_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if not isinstance(entry, dict) or "benchmark" not in entry:
+                continue
+            primary = entry.get("primaryMetric", {})
+            if "score" not in primary:
+                continue
+            mode = entry.get("mode", "")
+            direction = "higher" if mode in HIGHER_IS_BETTER_MODES else "lower"
+            key = f"micro/{short_name(entry['benchmark'])}"
+            metrics[key] = {
+                "value": primary["score"],
+                "error": primary.get("scoreError"),
+                "unit": primary.get("scoreUnit", ""),
+                "direction": direction,
+            }
+    return metrics
+
+
+def prune_old_runs(runs_dir: Path, max_age_days: int, now: datetime) -> None:
+    """Deletes run files whose filename date prefix is older than the cutoff."""
+    cutoff = now - timedelta(days=max_age_days)
+    for path in runs_dir.glob("*.json"):
+        timestamp = parse_filename_date(path.name)
+        if timestamp is not None and timestamp < cutoff:
+            print(f"Pruning baseline entry older than {max_age_days} days: {path.name}")
+            path.unlink()
+
+
+def parse_filename_date(filename: str) -> Optional[datetime]:
+    try:
+        return datetime.strptime(filename[:16], "%Y-%m-%dT%H-%M").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--macro-dir", type=Path, required=True)
+    parser.add_argument("--micro-dir", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--date", required=True, help="ISO 8601 UTC run date")
+    parser.add_argument("--runner", default="unknown")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prune-dir", type=Path, default=None)
+    parser.add_argument("--prune-days", type=int, default=60)
+    args = parser.parse_args()
+
+    macro = collect_macro_metrics(args.macro_dir) if args.macro_dir.is_dir() else {}
+    micro = collect_micro_metrics(args.micro_dir) if args.micro_dir.is_dir() else {}
+    if not macro and not micro:
+        print("No benchmark results found in either directory.", file=sys.stderr)
+        return 1
+
+    summary = {
+        "schema": SCHEMA_VERSION,
+        "commit": args.commit,
+        "date": args.date,
+        "runner": args.runner,
+        "metrics": {**macro, **micro},
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"Wrote {len(macro)} macro and {len(micro)} micro metrics to {args.output}")
+
+    if args.prune_dir is not None and args.prune_dir.is_dir():
+        now = datetime.fromisoformat(args.date.replace("Z", "+00:00"))
+        prune_old_runs(args.prune_dir, args.prune_days, now)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,0 +1,95 @@
+name: PR benchmarks
+
+# Opt-in PR benchmark comparison: tick "Run benchmarks" in the PR description to run
+# the full benchmark suite (benchmark-run.yml, same procedure as the daily master
+# baseline) and get a sticky comment comparing the results against the rolling window
+# of master baselines stored on the benchmark-data branch. The verdict is advisory
+# only and never blocks a merge.
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Cheap gate so unticked PRs cost seconds, mirroring the "Force running tests"
+  # checkbox handling in check.yml.
+  opt-in:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check the benchmark checkbox
+        id: check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qE '\- \[x\] Run benchmarks'; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    needs: opt-in
+    if: needs.opt-in.outputs.enabled == 'true'
+    uses: ./.github/workflows/benchmark-run.yml
+    secrets: inherit
+
+  compare:
+    runs-on: ubuntu-latest
+    needs: run
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          ref: benchmark-data
+          path: benchmark-data
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          path: results
+
+      - name: Build comparison comment
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 .github/scripts/extract_benchmark_summary.py \
+            --macro-dir results/macrobenchmark-results \
+            --micro-dir results/microbenchmark-results \
+            --commit "$PR_HEAD_SHA" \
+            --date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --runner "$RUNNER_OS" \
+            --output pr-summary.json
+          python3 .github/scripts/compare_benchmarks.py \
+            --pr-summary pr-summary.json \
+            --baseline-dir benchmark-data/runs \
+            --window 10 \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output comment.md
+
+      # Updates the existing comparison comment when one exists (found via the hidden
+      # HTML marker on its first line) instead of stacking a new comment per run.
+      - name: Upsert PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker='<!-- benchmark-comparison -->'
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" | head -n1)"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -F body=@comment.md
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@comment.md
+          fi

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -1,0 +1,109 @@
+name: Benchmark run
+
+# Reusable benchmark execution shared by the daily baseline workflow (benchmark.yml)
+# and the opt-in PR comparison workflow (benchmark-pr.yml), so baseline and PR numbers
+# always come from the exact same measurement procedure. Produces the merged
+# benchmark-results artifact with macrobenchmark-results/ and microbenchmark-results/
+# subdirectories.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+# Consumed by settings.gradle.kts to authenticate against the
+# Stockfish-Multiplatform GitHub Packages repository.
+env:
+  GITHUB_ACTOR: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  macrobenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      # suppressErrors=EMULATOR is required because Macrobenchmark refuses emulators by
+      # default; treat the resulting numbers as relative indicators, not absolute values.
+      - name: Run macrobenchmarks on the Gradle Managed Device
+        run: |
+          ./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: macrobenchmark-results
+          path: |
+            macrobenchmark/build/outputs/**/*.json
+            macrobenchmark/build/outputs/**/*.perfetto-trace
+          retention-days: 30
+
+  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
+  # with the macrobenchmark job.
+  microbenchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update local.properties
+        run: .github/scripts/update_properties.sh
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+
+      - name: Run JVM microbenchmarks
+        run: ./gradlew :microbenchmark:benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: microbenchmark-results
+          path: microbenchmark/build/reports/benchmarks/**/*.json
+          retention-days: 30
+
+  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
+  # final job merges their uploads into the single benchmark-results artifact consumers
+  # download. Each source artifact lands in its own subdirectory.
+  merge-results:
+    runs-on: ubuntu-latest
+    needs: [macrobenchmark, microbenchmark]
+    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
+    steps:
+      - name: Merge benchmark artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: benchmark-results
+          pattern: '{macrobenchmark,microbenchmark}-results'
+          separate-directories: true
+          delete-merged: true
+          retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,107 +1,68 @@
 name: Performance benchmarks
 
-# Manual trigger only: benchmarks take long, the macro job needs an emulator, and their
-# numbers on shared CI hardware are only useful for relative comparisons, so they stay out
-# of the PR checks.
+# Daily baseline run on master, plus manual dispatch. Benchmark numbers on shared CI
+# hardware are only useful for relative comparisons, so each master run is summarized
+# and recorded on the benchmark-data branch; opt-in PR runs (benchmark-pr.yml) compare
+# against the rolling window of those baselines.
 on:
   workflow_dispatch:
+    inputs:
+      record_baseline:
+        description: Record this run in the benchmark-data baseline (master only)
+        type: boolean
+        default: true
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: read
 
-# Consumed by settings.gradle.kts to authenticate against the
-# Stockfish-Multiplatform GitHub Packages repository.
-env:
-  GITHUB_ACTOR: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
-  macrobenchmark:
+  run:
+    uses: ./.github/workflows/benchmark-run.yml
+    secrets: inherit
+
+  # Appends this run's summary to the benchmark-data branch. Guarded to master so the
+  # baseline always describes master; a manual dispatch on any other branch still runs
+  # the benchmarks and uploads the artifact but never touches the baseline. Manual
+  # dispatches on master record too, which allows seeding the baseline window quickly.
+  record-baseline:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    needs: run
+    if: github.ref == 'refs/heads/master' && (github.event_name == 'schedule' || inputs.record_baseline)
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
-      - name: Update local.properties
-        run: .github/scripts/update_properties.sh
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: true
-
-      # suppressErrors=EMULATOR is required because Macrobenchmark refuses emulators by
-      # default; treat the resulting numbers as relative indicators, not absolute values.
-      - name: Run macrobenchmarks on the Gradle Managed Device
-        run: |
-          ./gradlew :macrobenchmark:pixel6Api34BenchmarkAndroidTest \
-            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
-            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: macrobenchmark-results
-          path: |
-            macrobenchmark/build/outputs/**/*.json
-            macrobenchmark/build/outputs/**/*.perfetto-trace
-          retention-days: 30
-
-  # JVM microbenchmarks for the pure Kotlin core: no emulator, no KVM, runs in parallel
-  # with the macrobenchmark job.
-  microbenchmark:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
       - uses: actions/checkout@v6
-
-      - name: Update local.properties
-        run: .github/scripts/update_properties.sh
-
-      - uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          ref: benchmark-data
+          path: benchmark-data
 
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: true
-
-      - name: Run JVM microbenchmarks
-        run: ./gradlew :microbenchmark:benchmark
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: microbenchmark-results
-          path: microbenchmark/build/reports/benchmarks/**/*.json
-          retention-days: 30
-
-  # The two benchmark jobs run in parallel and cannot write to the same artifact, so a
-  # final job merges their uploads into the single benchmark-results artifact consumers
-  # download. Each source artifact lands in its own subdirectory.
-  merge-results:
-    runs-on: ubuntu-latest
-    needs: [macrobenchmark, microbenchmark]
-    if: always() && (needs.macrobenchmark.result != 'cancelled' || needs.microbenchmark.result != 'cancelled')
-    steps:
-      - name: Merge benchmark artifacts
-        uses: actions/upload-artifact/merge@v7
+      - uses: actions/download-artifact@v8
         with:
           name: benchmark-results
-          pattern: '{macrobenchmark,microbenchmark}-results'
-          separate-directories: true
-          delete-merged: true
-          retention-days: 30
+          path: results
+
+      - name: Extract run summary
+        run: |
+          stamp="$(date -u +%Y-%m-%dT%H-%M)"
+          python3 .github/scripts/extract_benchmark_summary.py \
+            --macro-dir results/macrobenchmark-results \
+            --micro-dir results/microbenchmark-results \
+            --commit "$GITHUB_SHA" \
+            --date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --runner "$RUNNER_OS" \
+            --output "benchmark-data/runs/${stamp}_${GITHUB_SHA::8}.json" \
+            --prune-dir benchmark-data/runs \
+            --prune-days 60
+
+      - name: Commit baseline entry
+        working-directory: benchmark-data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add runs
+          git commit -m "chore: record benchmark baseline for ${GITHUB_SHA::8}"
+          git push origin benchmark-data


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## What

Stacked on #193 (uses the :microbenchmark module).

- **Daily baseline**: `benchmark.yml` gains a 03:00 UTC cron next to the existing manual dispatch. Master runs record a unified summary (macro + micro metrics, per metric direction) as one JSON on the new orphan `benchmark-data` branch, pruned after 60 days. Manual dispatch on master records too (fast baseline seeding); other branches run without recording (`record_baseline` input to opt out).
- **Reusable execution**: the three benchmark jobs move to `benchmark-run.yml` (`workflow_call`) so baseline and PR runs measure identically.
- **PR opt in**: new "Run benchmarks" checkbox in the PR template; `benchmark-pr.yml` gates on it in seconds, runs the suite, and upserts one sticky comparison comment.
- **Comparison**: `compare_benchmarks.py` compares against the mean ± σ of the last 10 master baselines. Thresholds: max(2σ, 1%) for emulator macrobenchmarks, max(2σ, 3%) for JVM microbenchmarks. Verdicts (✅/⚠️/🟢) are advisory only, never blocking.

## Verification

Both scripts exercised locally with fixture data covering: within noise, regression, improvement (both directions), zero mean metrics, metric missing from baselines, empty baseline store, and pruning of entries older than 60 days. All workflow YAML parse validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)