### PR TITLE
ci: collapse android-tests matrix to a single emulator

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -313,7 +313,8 @@ jobs:
         if: always()
         with:
           name: android-test-results
-          path: androidApp/build/outputs/androidTest-results/connected/*.xml
+          path: androidApp/build/outputs/androidTest-results/**/*.xml
+          if-no-files-found: error
           retention-days: 1
 
   # Full tier: wasmJs tests (no coverage - Kover does not support wasmJs)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -240,16 +240,12 @@ jobs:
       - name: Assemble the benchmark modules
         run: ./gradlew :macrobenchmark:assembleBenchmark :microbenchmark:assemble
 
-  # Full tier: Android instrumented tests, sharded across emulators
+  # Full tier: Android instrumented tests on a single emulator
   android-tests:
     needs: [detect]
     if: needs.detect.outputs.tier == 'full'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        shard_index: [0, 1, 2, 3]
-      fail-fast: false
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -303,17 +299,12 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 4096 -partition-size 4096
           disable-animations: true
-          script: ./gradlew :androidApp:connectedCheck --no-daemon -PshardIndex=${{ matrix.shard_index }} -PnumShards=4
-
-      - name: Rename coverage report
-        run: |
-          mkdir -p androidApp/build/outputs/code_coverage/${{ matrix.shard_index }}/
-          find androidApp/build/outputs/code_coverage/ -name "*.ec" -exec cp {} androidApp/build/outputs/code_coverage/${{ matrix.shard_index }}/ \;
+          script: ./gradlew :androidApp:connectedCheck --no-daemon
 
       - name: Upload coverage to GitHub
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report-android-${{ matrix.shard_index }}
+          name: coverage-report-android
           path: androidApp/build/outputs/code_coverage/
           retention-days: 1
 
@@ -321,7 +312,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: android-test-results-${{ matrix.shard_index }}
+          name: android-test-results
           path: androidApp/build/outputs/androidTest-results/connected/*.xml
           retention-days: 1
 
@@ -418,9 +409,8 @@ jobs:
         if: needs.detect.outputs.tier == 'full' && needs.android-tests.result != 'skipped'
         uses: actions/download-artifact@v8
         with:
-          pattern: android-test-results-*
+          name: android-test-results
           path: test-results/android
-          merge-multiple: true
 
       - name: Download Wasm test results
         if: needs.detect.outputs.tier == 'full' && needs.wasm-tests.result != 'skipped'
@@ -495,7 +485,7 @@ jobs:
         if: needs.detect.outputs.tier == 'full'
         uses: actions/download-artifact@v8
         with:
-          pattern: coverage-report-android-*
+          name: coverage-report-android
           path: androidApp/build/outputs/code_coverage/
 
       - name: Download JVM Kover report

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -22,10 +22,6 @@ android {
     versionCode = 1
     versionName = "0.0.1"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArguments["numShards"] =
-      project.findProperty("numShards")?.toString() ?: "1"
-    testInstrumentationRunnerArguments["shardIndex"] =
-      project.findProperty("shardIndex")?.toString() ?: "0"
   }
 
   packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }

--- a/docs/adr/0001-three-tier-ci-checks.md
+++ b/docs/adr/0001-three-tier-ci-checks.md
@@ -42,9 +42,9 @@ runs `dorny/paths-filter@v3` against the diff:
   `iosMain`, `wasmJsMain`, `nonJsMain`, `debugMain`, an Android
   manifest, any `*.gradle.kts`, `gradle/libs.versions.toml`, or
   `.github/workflows/check.yml` touched. Runs the cheap-tier set plus
-  `android-tests` (4-shard matrix in `androidApp`), `wasm-tests`, and
+  `android-tests` (single emulator in `androidApp`), `wasm-tests`, and
   a standalone `sonar-analysis` job that aggregates JVM Kover with the
-  per shard Android jacoco reports. Scheduled cron runs and the
+  Android jacoco reports. Scheduled cron runs and the
   `[x] Force running tests` PR body checkbox also pin to full.
 
 The `[skip-tests]` PR title override (forces noop) was kept.
@@ -75,9 +75,10 @@ sense once the tier topology was in place:
 Three things that were tried and reverted:
 
 - Collapsing the 4-shard Android matrix to a single emulator. The
-  codebase has 132 instrumented tests; the single emulator hangs at
+  codebase has 132 instrumented tests; the single emulator hung at
   test 31 (related to `TestStockfishEvaluator`, tracked in
-  issue #138). The matrix stays at 4.
+  issue #138). The matrix stayed at 4 until issue #138 was fixed,
+  after which the job was collapsed to a single emulator.
 - Using `-no-snapshot-save` to actually load the cached AVD snapshot.
   The snapshot saved by the create AVD step is incompatible with the
   test run step ("Failed to load snapshot 'default_boot'"), so the


### PR DESCRIPTION
## Summary
- Remove the 4-way `shard_index` matrix from `android-tests`; all 132 instrumented tests now run on one emulator.
- Drop the now-unused `numShards`/`shardIndex` instrumentation runner args from `androidApp/build.gradle.kts`.
- Merge per-shard artifacts into single `coverage-report-android` / `android-test-results` artifacts and update the download steps (jacoco still globs `outputs/code_coverage/**/*.ec`, so the layout change is transparent).
- Raise the job timeout to 45 minutes since one emulator runs the full suite.
- Update ADR 0001: the earlier single-emulator attempt was reverted because of issue #138, which is now fixed (closed 2026-06-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)