### PR TITLE
perf(ui): paint board tiles in a single drawBehind

### DIFF
--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
@@ -2,12 +2,16 @@ package proj.memorchess.axl.ui.components.board
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
@@ -23,6 +27,7 @@ import proj.memorchess.axl.core.config.CHESS_BOARD_COLOR_SETTING
 import proj.memorchess.axl.core.config.MOVE_ANIMATION_DURATION_SETTING
 import proj.memorchess.axl.core.engine.BoardLocation
 import proj.memorchess.axl.core.engine.BoardUtils
+import proj.memorchess.axl.core.engine.TileColor
 import proj.memorchess.axl.ui.theme.KineticMotion
 
 /**
@@ -69,32 +74,56 @@ fun BoardGrid(
 /**
  * Composable function that draws the grid of tiles on the chessboard.
  *
- * Iterates over all board locations, rendering each tile and handling click events. Highlights the
- * selected tile. Tile pixel positions for piece animation are derived once by [BoardGrid] from a
- * single measurement rather than per tile here.
+ * The 64 cells exist only to carry the per-tile clickable semantics (click label and on-screen
+ * position) that tests and accessibility rely on. Tile backgrounds and the selection highlight are
+ * painted in a single [drawBehind] on the grid instead of per-cell composables, so selecting a tile
+ * only invalidates the draw phase. Tile pixel positions for piece animation are derived once by
+ * [BoardGrid] from a single measurement rather than per tile here.
  *
  * @param state The board state containing tile information and selection.
  * @param scope Coroutine scope for handling tile click events asynchronously.
  */
 @Composable
 private fun DrawTileGrid(state: BoardGridState, scope: CoroutineScope) {
+  val colors = CHESS_BOARD_COLOR_SETTING.getValue()
+  val borderWidth = with(LocalDensity.current) { 3.dp.toPx() }
   DrawGrid(
+    modifier =
+      Modifier.drawBehind {
+        val tileSize = size.width / 8f
+        val selected = state.selectedTile
+        for (index in 0..63) {
+          val location = state.getBoardLocationAt(index)
+          val topLeft = Offset(index % 8 * tileSize, index / 8 * tileSize)
+          drawRect(
+            color =
+              if (location.color == TileColor.BLACK) colors.darkSquareColor
+              else colors.lightSquareColor,
+            topLeft = topLeft,
+            size = Size(tileSize, tileSize),
+          )
+          if (
+            selected != null && selected.first == location.row && selected.second == location.col
+          ) {
+            // Inset by half the stroke so the border stays inside the tile, matching the previous
+            // Modifier.border rendering.
+            drawRect(
+              color = colors.selectedBorderColor,
+              topLeft = topLeft + Offset(borderWidth / 2f, borderWidth / 2f),
+              size = Size(tileSize - borderWidth, tileSize - borderWidth),
+              style = Stroke(borderWidth),
+            )
+          }
+        }
+      },
     boxModifier = {
       val location = state.getBoardLocationAt(it)
       val coords = Pair(location.row, location.col)
-      val isSelected = state.selectedTile == coords
       val tileName = BoardUtils.tileName(location.row, location.col)
       val clickLabel = stringResource(Res.string.description_board_tile, tileName)
       clickable(onClickLabel = clickLabel, onClick = { scope.launch { state.onTileClick(coords) } })
-        .then(
-          if (isSelected)
-            Modifier.border(3.dp, CHESS_BOARD_COLOR_SETTING.getValue().selectedBorderColor)
-          else Modifier
-        )
-    }
-  ) {
-    Tile(state.getBoardLocationAt(it))
-  }
+    },
+  ) {}
 }
 
 /**
@@ -138,14 +167,16 @@ private fun DrawPieceGrid(
  * Iterates over rows and columns, applying the provided boxModifier and boxContent for each tile.
  *
  * @param boxModifier Modifier applied to each grid tile, can be used for click handling or styling.
+ * @param modifier Modifier applied to the grid as a whole, e.g. to paint all tile backgrounds.
  * @param boxContent Content composable for each grid tile, typically used to render tile or piece.
  */
 @Composable
 private fun DrawGrid(
   boxModifier: @Composable Modifier.(Int) -> Modifier,
+  modifier: Modifier = Modifier,
   boxContent: @Composable (RowScope.(Int) -> Unit),
 ) {
-  Column {
+  Column(modifier = modifier) {
     for (rowIndex in 0..7) {
       Row(modifier = Modifier.fillMaxSize().weight(1f)) {
         for (colIndex in 0..7) {


### PR DESCRIPTION
First optimization from #160: move tile backgrounds and the selection highlight into a single `drawBehind` on the tile grid, removing the 64 `Tile` composables.

## What changed

- `DrawTileGrid` no longer composes a `Tile` per cell. All 64 backgrounds plus the selection border are painted in one `drawBehind` on the grid `Column`, cutting 64 composable nodes from the board build.
- The 64 grid cells remain as clickable boxes carrying the unchanged semantics: `onClickLabel` from `description_board_tile` and on-screen positions, so `hasClickLabel(getTileDescription(...))` lookups and board-inversion checks keep working. Piece test tags are untouched.
- `state.selectedTile` is now read inside the draw lambda, so selecting a tile invalidates only the draw phase instead of recomposing cells.
- Board inversion handling is unchanged: the draw loop reuses `state.getBoardLocationAt(index)`, the same mapping the cells use.
- The `Tile` composable itself stays because the color scheme preview in `debugMain` uses it.

## Expected effect

Baseline (master, `c5c3ed5d`): `%BoardGrid%Count` median 263, `%BoardGrid%SumMs` median ~117 ms on Explore entry. This change should reduce the node count and composition time; the benchmark comparison below will tell by how much.

Closes nothing yet; #160 stays open for the remaining candidates depending on the numbers.

## Options

- [ ] Force running tests
- [x] Run benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
