### PR TITLE
perf(ui): resolve board description templates once per grid

### DIFF
--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
@@ -282,3 +282,14 @@ private fun AnimatedPiece(
     state.piecesToMove.remove(location)
   }
 }
+
+/**
+ * Formats a single-placeholder string resource template without going through the resource
+ * formatter, so bulk callers pay the resource lookup only once for the template.
+ *
+ * @param template Raw resource string containing a `%1$s` placeholder.
+ * @param argument Value substituted for the placeholder.
+ */
+private fun formatSingleArgTemplate(template: String, argument: String): String {
+  return template.replace($$"%1$s", argument)
+}

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/BoardGrid.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import memorchess.composeapp.generated.resources.Res
+import memorchess.composeapp.generated.resources.description_board_piece
 import memorchess.composeapp.generated.resources.description_board_tile
 import org.jetbrains.compose.resources.stringResource
 import proj.memorchess.axl.core.config.CHESS_BOARD_COLOR_SETTING
@@ -80,6 +81,9 @@ fun BoardGrid(
  * only invalidates the draw phase. Tile pixel positions for piece animation are derived once by
  * [BoardGrid] from a single measurement rather than per tile here.
  *
+ * The click label template is resolved through [stringResource] once for the whole grid and
+ * formatted per tile, because per-cell resource lookups dominated the board composition time.
+ *
  * @param state The board state containing tile information and selection.
  * @param scope Coroutine scope for handling tile click events asynchronously.
  */
@@ -87,6 +91,7 @@ fun BoardGrid(
 private fun DrawTileGrid(state: BoardGridState, scope: CoroutineScope) {
   val colors = CHESS_BOARD_COLOR_SETTING.getValue()
   val borderWidth = with(LocalDensity.current) { 3.dp.toPx() }
+  val tileDescriptionTemplate = stringResource(Res.string.description_board_tile)
   DrawGrid(
     modifier =
       Modifier.drawBehind {
@@ -120,7 +125,7 @@ private fun DrawTileGrid(state: BoardGridState, scope: CoroutineScope) {
       val location = state.getBoardLocationAt(it)
       val coords = Pair(location.row, location.col)
       val tileName = BoardUtils.tileName(location.row, location.col)
-      val clickLabel = stringResource(Res.string.description_board_tile, tileName)
+      val clickLabel = formatSingleArgTemplate(tileDescriptionTemplate, tileName)
       clickable(onClickLabel = clickLabel, onClick = { scope.launch { state.onTileClick(coords) } })
     },
   ) {}
@@ -132,6 +137,10 @@ private fun DrawTileGrid(state: BoardGridState, scope: CoroutineScope) {
  * Renders each piece at its corresponding tile location. Handles piece animation when a move
  * occurs, and displays the piece at its destination after the animation completes.
  *
+ * The piece content description template is resolved through [stringResource] once for the whole
+ * grid and formatted per piece, because per-cell resource lookups dominated the board composition
+ * time.
+ *
  * @param state The board state containing piece and move information.
  * @param animationDuration Duration for animating piece movement between tiles.
  * @param tilePositions Map of board locations to their pixel positions for animation.
@@ -142,6 +151,7 @@ private fun DrawPieceGrid(
   animationDuration: Duration,
   tilePositions: Map<BoardLocation, DpOffset>,
 ) {
+  val pieceDescriptionTemplate = stringResource(Res.string.description_board_piece)
   DrawGrid({ this }) {
     val location = state.getBoardLocationAt(it)
     Box(modifier = Modifier.aspectRatio(1f).weight(1f)) {
@@ -153,9 +163,13 @@ private fun DrawPieceGrid(
               !state.piecesToMove.values.contains(location)))
       ) {
         val tileName = BoardUtils.tileName(location.row, location.col)
-        Piece(piece, Modifier.fillMaxSize().testTag("Piece $piece at $tileName"))
+        Piece(
+          piece,
+          Modifier.fillMaxSize().testTag("Piece $piece at $tileName"),
+          contentDescription = formatSingleArgTemplate(pieceDescriptionTemplate, piece.toString()),
+        )
       } else if (animationDuration != Duration.ZERO && state.piecesToMove.contains(location)) {
-        AnimatedPiece(state, location, tilePositions, animationDuration)
+        AnimatedPiece(state, location, tilePositions, animationDuration, pieceDescriptionTemplate)
       }
     }
   }
@@ -200,6 +214,7 @@ private fun DrawGrid(
  * @param location The board location of the piece to animate.
  * @param tilePositions Map of board locations to their pixel offsets on the board.
  * @param animationDuration Duration of the slide, sourced once from the caller.
+ * @param pieceDescriptionTemplate Content description template, resolved once by the caller.
  */
 @Composable
 private fun AnimatedPiece(
@@ -207,6 +222,7 @@ private fun AnimatedPiece(
   location: BoardLocation,
   tilePositions: Map<BoardLocation, DpOffset>,
   animationDuration: Duration,
+  pieceDescriptionTemplate: String,
 ) {
   val destinationLocation = state.piecesToMove[location]
   val startPos = tilePositions[location]
@@ -258,6 +274,7 @@ private fun AnimatedPiece(
         IntOffset((x * offsetMultiplier).roundToPx(), (y * offsetMultiplier).roundToPx())
       }
       .fillMaxSize(),
+    contentDescription = formatSingleArgTemplate(pieceDescriptionTemplate, pieceToMove.toString()),
   )
   LaunchedEffect(Unit) {
     moved = true // NOSONAR: Compose state triggers recomposition

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/Piece.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/Piece.kt
@@ -13,16 +13,35 @@ import proj.memorchess.axl.core.engine.ChessPiece
  * Renders a single chess piece. Reads the painter from [LocalPiecePainters] — preloaded once at the
  * theme layer — so mounting 32 pieces on board reentry is a synchronous map lookup rather than 32
  * async resource loads.
+ *
+ * @param piece The piece to render.
+ * @param modifier Modifier for customizing the image.
+ * @param contentDescription Accessibility description. Callers that mount many pieces at once
+ *   should resolve the description template once and format it per piece with
+ *   [formatSingleArgTemplate], because per-piece [stringResource] lookups are slow in bulk. When
+ *   null, the description is resolved here.
  */
 @Composable
-fun Piece(piece: ChessPiece, modifier: Modifier = Modifier) {
+fun Piece(piece: ChessPiece, modifier: Modifier = Modifier, contentDescription: String? = null) {
   val painter =
     LocalPiecePainters.current[piece]
       ?: error("No painter cached for $piece — PiecePaintersProvider not in scope")
   Image(
     painter = painter,
-    contentDescription = stringResource(Res.string.description_board_piece, piece.toString()),
+    contentDescription =
+      contentDescription ?: stringResource(Res.string.description_board_piece, piece.toString()),
     contentScale = ContentScale.Fit,
     modifier = modifier,
   )
+}
+
+/**
+ * Formats a single-placeholder string resource template without going through the resource
+ * formatter, so bulk callers pay the resource lookup only once for the template.
+ *
+ * @param template Raw resource string containing a `%1$s` placeholder.
+ * @param argument Value substituted for the placeholder.
+ */
+internal fun formatSingleArgTemplate(template: String, argument: String): String {
+  return template.replace("%1\$s", argument)
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/Piece.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/Piece.kt
@@ -16,10 +16,7 @@ import proj.memorchess.axl.core.engine.ChessPiece
  *
  * @param piece The piece to render.
  * @param modifier Modifier for customizing the image.
- * @param contentDescription Accessibility description. Callers that mount many pieces at once
- *   should resolve the description template once and format it per piece with
- *   [formatSingleArgTemplate], because per-piece [stringResource] lookups are slow in bulk. When
- *   null, the description is resolved here.
+ * @param contentDescription Accessibility description.
  */
 @Composable
 fun Piece(piece: ChessPiece, modifier: Modifier = Modifier, contentDescription: String? = null) {
@@ -33,15 +30,4 @@ fun Piece(piece: ChessPiece, modifier: Modifier = Modifier, contentDescription: 
     contentScale = ContentScale.Fit,
     modifier = modifier,
   )
-}
-
-/**
- * Formats a single-placeholder string resource template without going through the resource
- * formatter, so bulk callers pay the resource lookup only once for the template.
- *
- * @param template Raw resource string containing a `%1$s` placeholder.
- * @param argument Value substituted for the placeholder.
- */
-internal fun formatSingleArgTemplate(template: String, argument: String): String {
-  return template.replace("%1\$s", argument)
 }


### PR DESCRIPTION
Second optimization for #160, this time guided by the perfetto traces from the PR #197 benchmark run instead of node counts.

## What the trace showed

Querying the `BoardCompositionBenchmark` traces with perfetto trace_processor:

- The board composes exactly once per Explore entry (no recomposition storm); the 263 `%BoardGrid%` sections are nested children of one composition.
- Of a ~70 ms board build (iter005), `DrawTileGrid` was 59 ms, and 52.8 ms of that was `org.jetbrains.compose.resources.stringResource`: one call per tile for the click label. `Piece` adds 32 more calls for content descriptions.
- The cost recurs on every board entry (it is not a one-time string table parse): each iteration pays 13 to 66 ms total in `stringResource`, with single calls spiking up to 47 ms.

## What changed

- `DrawTileGrid` resolves the `description_board_tile` template once per grid and formats the 64 click labels with a plain placeholder substitution.
- `DrawPieceGrid` does the same with `description_board_piece` and passes the formatted description to `Piece` (new optional `contentDescription` parameter, defaults to the old per-piece lookup for other callers).
- Net effect: 96 `stringResource` calls per board build become 2.

Labels and descriptions are byte-identical to before ("Tile e4", "Piece p at e4" semantics untouched), both locales use the same `%1$s` placeholder, and the existing UI tests assert the click labels.

## Expected effect

`%BoardGrid%SumMs` should drop on the order of 2x (baseline median ~102 ms), and Explore-entry frame tails should improve beyond the noise band this time.

## Options

- [ ] Force running tests
- [x] Run benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
