### PR TITLE
test(perf): drop FrameTimingMetric from BoardCompositionBenchmark

### DIFF
--- a/macrobenchmark/README.md
+++ b/macrobenchmark/README.md
@@ -68,6 +68,6 @@ The `benchmark.yml` workflow wires this up on GitHub Actions behind a manual tri
 
 - Compare numbers from the same device only. Emulator runs depend on host load.
 - `frameDurationCpuMs` percentiles (P50/P90/P95/P99) are the headline numbers for navigation.
-- For `BoardCompositionBenchmark`, composition tracing itself adds a small overhead to every
-  composable, so use its `FrameTimingMetric` values as relative indicators only;
-  `ScreenNavigationBenchmark` is the clean frame timing source.
+- `BoardCompositionBenchmark` deliberately reports no `FrameTimingMetric`: composition tracing
+  adds overhead to every composable, and on CI emulators the frame timeline regularly yields no
+  expect/actual slices, failing the run. `ScreenNavigationBenchmark` is the frame timing source.

--- a/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BoardCompositionBenchmark.kt
+++ b/macrobenchmark/src/main/kotlin/proj/memorchess/axl/macrobenchmark/BoardCompositionBenchmark.kt
@@ -1,7 +1,6 @@
 package proj.memorchess.axl.macrobenchmark
 
 import androidx.benchmark.macro.ExperimentalMetricApi
-import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.TraceSectionMetric
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
@@ -19,9 +18,10 @@ import org.junit.runner.RunWith
  * per composable. No marker code exists in the app itself.
  *
  * Each iteration starts on Settings (no board) and measures the navigation into Explore, so the
- * board is composed from scratch inside the measured window. Composition tracing adds a small
- * overhead to every composable, so treat the accompanying frame timing numbers as relative
- * indicators only; [ScreenNavigationBenchmark] is the clean frame timing source.
+ * board is composed from scratch inside the measured window. This benchmark deliberately carries no
+ * [androidx.benchmark.macro.FrameTimingMetric]: composition tracing skews frame numbers, and on CI
+ * emulators the frame timeline regularly produces no expect/actual slices at all, which fails the
+ * whole run. [ScreenNavigationBenchmark] is the frame timing source.
  */
 @OptIn(ExperimentalMetricApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -33,8 +33,7 @@ class BoardCompositionBenchmark {
   fun boardCompositionOnExploreEntry() {
     benchmarkRule.measureRepeated(
       packageName = TARGET_PACKAGE,
-      metrics =
-        listOf(TraceSectionMetric("%BoardGrid%", TraceSectionMetric.Mode.Sum), FrameTimingMetric()),
+      metrics = listOf(TraceSectionMetric("%BoardGrid%", TraceSectionMetric.Mode.Sum)),
       iterations = 10,
       startupMode = StartupMode.WARM,
       setupBlock = {


### PR DESCRIPTION
## Why

Today's baseline seeding (13 dispatches of `benchmark.yml`) lost 3 runs to the same failure:

```
proj.memorchess.axl.macrobenchmark.BoardCompositionBenchmark > boardCompositionOnExploreEntry[pixel6Api34] FAILED
java.lang.IllegalStateException: Observed no expect/actual slices in trace, please report bug and attach perfetto trace.
```

`FrameTimingMetric` queries SurfaceFlinger frame timeline slices from the perfetto trace. On the CI managed emulator (swiftshader, shared runner) those slices are regularly absent, the metric throws, the macrobenchmark job fails and `record-baseline` is skipped, so the run produces no data point. Failure rate today was about 23 percent (runs 27409887963, 27410260369, 27420007976; passes interleaved on the same commits, so flake, not regression).

## What

- Remove `FrameTimingMetric` from `BoardCompositionBenchmark`, keeping `TraceSectionMetric("%BoardGrid%")`, which is the metric this benchmark exists for. Its frame timing numbers were already documented as relative indicators only, since composition tracing skews them; `ScreenNavigationBenchmark` remains the clean frame timing source and is untouched.
- Update the KDoc and `macrobenchmark/README.md` accordingly.

No consumer change needed: `extract_benchmark_summary.py` flattens whatever metrics exist, and `compare_benchmarks.py` only compares keys present in the PR run, so the `frameDurationCpuMs` keys for this benchmark simply stop appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)