### PR TITLE
feat(core): ordered introduction of new moves

### DIFF
--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DataMove.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DataMove.kt
@@ -26,6 +26,14 @@ data class DataMove(
   /** Whether the move has been deleted. */
   val isDeleted: Boolean = false,
 
+  /**
+   * Date at which this move was first added.
+   *
+   * Excluded from equality like [updatedAt]: two moves describing the same transition are the same
+   * move regardless of when they were recorded.
+   */
+  val createdAt: Instant = DateUtil.now(),
+
   /** Date at which this move was updated */
   val updatedAt: Instant = DateUtil.now(),
 ) {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/Edge.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/Edge.kt
@@ -20,6 +20,9 @@ import proj.memorchess.axl.core.data.PositionKey
  * @property isGood Whether the move is part of the user's intended repertoire. `null` for a move
  *   that was explored but not yet classified. A `false` value flags a move kept around as a known
  *   mistake to drill against.
+ * @property createdAt Moment the edge was first added to the repertoire. Unlike [updatedAt], it is
+ *   preserved by [TreeStore.addMove] across re-upserts, which makes it a stable sibling order for
+ *   the introduction of new cards (see [OpeningTree.introductionOrder]).
  * @property updatedAt Last time the edge was written. Stamped by [TreeStore].
  * @property isDeleted Tombstone flag used by [DeleteMode.SOFT].
  */
@@ -28,6 +31,7 @@ data class Edge(
   val move: String,
   val to: PositionKey,
   val isGood: Boolean?,
+  val createdAt: Instant,
   val updatedAt: Instant,
   val isDeleted: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
@@ -16,7 +16,7 @@ import proj.memorchess.axl.core.scheduling.CardState
  *   `<index>\t<positionKey>\t<depth>\t<dueDate>\t<lastReview>\t<stability>\t<difficulty>\t<reps>\t<lapses>\t<phase>\t<step>\t<updatedAt>`
  *   where `<lastReview>` is the literal string `null` for a card that has never been reviewed and
  *   `<phase>` is a [proj.memorchess.axl.core.scheduling.CardPhase] name.
- * - **Edge lines**: `<originIndex>\t<destIndex>\t<move>\t<isGood>\t<updatedAt>`
+ * - **Edge lines**: `<originIndex>\t<destIndex>\t<move>\t<isGood>\t<updatedAt>\t<createdAt>`
  *
  * Nodes are sorted by [PositionKey.value] and edges by `(originIndex, destIndex, move)` for
  * determinism.
@@ -30,6 +30,7 @@ object GraphSerializer {
   private const val UNKNOWN = "?"
   private const val NULL_TOKEN = "null"
   private const val NODE_FIELD_COUNT = 12
+  private const val EDGE_FIELD_COUNT = 6
 
   /** Serializes nodes to a deterministic text string. Filters out deleted nodes and moves. */
   fun serialize(nodes: List<DataNode>): String {
@@ -62,7 +63,16 @@ object GraphSerializer {
         val originIdx = indexByKey[node.positionKey]!!
         for (dataMove in node.previousAndNextMoves.filterNotDeleted().nextMoves.values) {
           val destIdx = indexByKey[dataMove.destination] ?: continue
-          add(Edge(originIdx, destIdx, dataMove.move, dataMove.isGood, dataMove.updatedAt))
+          add(
+            Edge(
+              originIdx,
+              destIdx,
+              dataMove.move,
+              dataMove.isGood,
+              dataMove.updatedAt,
+              dataMove.createdAt,
+            )
+          )
         }
       }
     }
@@ -145,7 +155,7 @@ object GraphSerializer {
     if (section.isEmpty()) return emptyList()
     return section.lines().map { line ->
       val parts = line.split(TAB)
-      require(parts.size == 5) { "Invalid edge line: $line" }
+      require(parts.size == EDGE_FIELD_COUNT) { "Invalid edge line: $line" }
       val originIndex = parts[0].toInt()
       val destIndex = parts[1].toInt()
       require(originIndex in nodeEntries && destIndex in nodeEntries) {
@@ -157,6 +167,7 @@ object GraphSerializer {
         move = parts[2],
         isGood = parseIsGood(parts[3]),
         updatedAt = Instant.parse(parts[4]),
+        createdAt = Instant.parse(parts[5]),
       )
     }
   }
@@ -182,9 +193,11 @@ object GraphSerializer {
     val move: String,
     val isGood: Boolean?,
     val updatedAt: Instant,
+    val createdAt: Instant,
   ) {
     fun toLine(): String =
-      listOf(originIndex, destIndex, move, isGoodToChar(isGood), updatedAt).joinToString(TAB)
+      listOf(originIndex, destIndex, move, isGoodToChar(isGood), updatedAt, createdAt)
+        .joinToString(TAB)
   }
 
   private data class NodeEntry(
@@ -200,7 +213,9 @@ object GraphSerializer {
     val move: String,
     val isGood: Boolean?,
     val updatedAt: Instant,
+    val createdAt: Instant,
   ) {
-    fun toDataMove(): DataMove = DataMove(origin, destination, move, isGood, updatedAt = updatedAt)
+    fun toDataMove(): DataMove =
+      DataMove(origin, destination, move, isGood, createdAt = createdAt, updatedAt = updatedAt)
   }
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/OpeningTree.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/OpeningTree.kt
@@ -46,6 +46,48 @@ class OpeningTree {
   }
 
   /**
+   * Computes a deterministic introduction order over every position in the graph.
+   *
+   * The order is a depth first traversal from [PositionKey.START_POSITION]: a whole line is
+   * numbered from the start position to its end before the traversal backtracks to the next branch.
+   * Sibling branches are visited oldest [Edge.createdAt] first, with the move SAN as a tiebreak, so
+   * lines are introduced in the order they were added to the repertoire. Deleted edges are not
+   * followed. A transposition is numbered at its first visit only. Positions not reachable from the
+   * start position are appended at the end, ordered by depth then position key.
+   *
+   * Recomputed from scratch on every call. If this ever shows up in the opening tree benchmark,
+   * memoize on the snapshot identity.
+   *
+   * @return Index of every position in the introduction order, starting at 0.
+   */
+  fun introductionOrder(): Map<PositionKey, Int> {
+    val order = mutableMapOf<PositionKey, Int>()
+    val stack = ArrayDeque<PositionKey>()
+    if (PositionKey.START_POSITION in positions) {
+      stack.addLast(PositionKey.START_POSITION)
+    }
+    while (stack.isNotEmpty()) {
+      val key = stack.removeLast()
+      if (key in order) continue
+      order[key] = order.size
+      val node = positions[key] ?: continue
+      val children =
+        node.outgoing.values
+          .filterNot { it.isDeleted }
+          .sortedWith(compareBy({ it.createdAt }, { it.move }))
+      // Reversed so that the oldest branch is popped first.
+      for (edge in children.asReversed()) {
+        if (edge.to !in order) stack.addLast(edge.to)
+      }
+    }
+    positions.keys
+      .filter { it !in order }
+      .sortedWith(compareBy({ getDepth(it) }, { it.value }))
+      .forEach { order[it] = order.size }
+    return order
+  }
+
+  /**
    * Computes the [NodeState] for [positionKey] given which position we arrived from.
    *
    * @param positionKey Position to compute the state for.

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.date.DateUtil
+import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.ReviewGrade
 import proj.memorchess.axl.core.scheduling.SchedulingAlgorithm
 
@@ -25,14 +26,17 @@ class TrainingScheduler(
   /**
    * Returns the next [TrainingEntry] to train, or `null` when there is nothing left for [day].
    *
-   * Selection runs in three tiers so that the in-session learning loop drains in step order without
+   * Selection runs in four tiers so that the in-session learning loop drains in step order without
    * starving the day's review queue:
    * 1. **Ready learning cards** — a [proj.memorchess.axl.core.scheduling.CardPhase.LEARNING] or
    *    `RELEARNING` card whose sub-day due moment has arrived. The earliest due wins, so a card on
    *    a one minute step surfaces before one on a ten minute step.
-   * 2. **Review and new cards** due on or before [day] — picked by smallest graph depth to follow
-   *    the natural opening order.
-   * 3. **Pending learning cards** — sub-day cards not yet due. Falling through to these guarantees
+   * 2. **Review cards** due on or before [day] — picked by smallest graph depth to follow the
+   *    natural opening order.
+   * 3. **New cards** due on or before [day] — picked by [OpeningTree.introductionOrder], so a whole
+   *    line is introduced before the next branch starts, in the order the lines were added to the
+   *    repertoire.
+   * 4. **Pending learning cards** — sub-day cards not yet due. Falling through to these guarantees
    *    a just-failed card always resurfaces in the same session rather than ending it early, again
    *    earliest-due first.
    *
@@ -50,8 +54,15 @@ class TrainingScheduler(
     if (readyLearning.isNotEmpty()) return readyLearning.minByOrNull { it.cardState.dueDate }
 
     val reviewLike = candidates.filterNot { it.cardState.isInSession() }
-    if (reviewLike.isNotEmpty()) {
-      return reviewLike.minByOrNull { treeStore.current().getDepth(it.positionKey) }
+    val reviews = reviewLike.filter { it.cardState.phase == CardPhase.REVIEW }
+    if (reviews.isNotEmpty()) {
+      return reviews.minByOrNull { treeStore.current().getDepth(it.positionKey) }
+    }
+
+    val newCards = reviewLike.filter { it.cardState.phase == CardPhase.NEW }
+    if (newCards.isNotEmpty()) {
+      val order = treeStore.current().introductionOrder()
+      return newCards.minByOrNull { order[it.positionKey] ?: Int.MAX_VALUE }
     }
 
     return candidates.minByOrNull { it.cardState.dueDate }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -78,6 +78,10 @@ class TreeStore(private val database: DatabaseQueryManager) {
    * durable, an exploration edge does not. The destination node is created on demand at depth
    * [fromDepth] + 1.
    *
+   * When the edge already exists its [Edge.createdAt] is preserved. This is load bearing:
+   * exploration replays a line by re-upserting every edge on the way, so a fresh stamp on each
+   * upsert would reshuffle the introduction order of new cards just by browsing.
+   *
    * @param from Position the move is played from.
    * @param move SAN of the move.
    * @param to Position reached by playing [move].
@@ -92,7 +96,16 @@ class TreeStore(private val database: DatabaseQueryManager) {
     isGood: Boolean?,
     fromDepth: Int,
   ): Edge {
-    val edge = Edge(from = from, move = move, to = to, isGood = isGood, updatedAt = DateUtil.now())
+    val createdAt = tree.get(from)?.outgoing?.get(move)?.createdAt ?: DateUtil.now()
+    val edge =
+      Edge(
+        from = from,
+        move = move,
+        to = to,
+        isGood = isGood,
+        createdAt = createdAt,
+        updatedAt = DateUtil.now(),
+      )
     tree.upsertEdge(edge, fromDepth)
     if (isGood != null) {
       persistNode(from)
@@ -159,6 +172,7 @@ private fun DataMove.toEdge(): Edge =
     move = move,
     to = destination,
     isGood = isGood,
+    createdAt = createdAt,
     updatedAt = updatedAt,
     isDeleted = isDeleted,
   )
@@ -170,6 +184,7 @@ private fun Edge.toDataMove(): DataMove =
     move = move,
     isGood = isGood,
     isDeleted = isDeleted,
+    createdAt = createdAt,
     updatedAt = updatedAt,
   )
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -145,7 +145,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
         touched += insertion.to
       }
     }
-    val nodesToPersist = touched.mapNotNull { tree.get(it)?.toDataNode() }
+    val nodesToPersist = touched.mapNotNull { tree[it]?.toDataNode() }
     if (nodesToPersist.isNotEmpty()) {
       database.insertNodes(*nodesToPersist.toTypedArray())
     }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -96,7 +96,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
     isGood: Boolean?,
     fromDepth: Int,
   ): Edge {
-    val createdAt = tree.get(from)?.outgoing?.get(move)?.createdAt ?: DateUtil.now()
+    val createdAt = tree[from]?.outgoing?.get(move)?.createdAt ?: DateUtil.now()
     val edge =
       Edge(
         from = from,

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -159,7 +159,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
    * back.
    */
   suspend fun updateCardState(positionKey: PositionKey, cardState: CardState) {
-    val existing = tree.get(positionKey)
+    val existing = tree[positionKey]
     if (existing == null) {
       LOGGER.w { "Skipping card state update for unknown position $positionKey" }
       return
@@ -178,7 +178,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
    * Deletes the node at [positionKey] and every incident edge, in both the cache and the database.
    */
   suspend fun deleteNode(positionKey: PositionKey, mode: DeleteMode = DeleteMode.HARD) {
-    val node = tree.get(positionKey)
+    val node = tree[positionKey]
     if (node != null) {
       for (edge in node.outgoing.values.toList()) {
         tree.removeEdge(positionKey, edge.move)
@@ -198,7 +198,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
   }
 
   private suspend fun persistNode(positionKey: PositionKey) {
-    val node = tree.get(positionKey) ?: return
+    val node = tree[positionKey] ?: return
     database.insertNodes(node.toDataNode())
   }
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -129,12 +129,14 @@ class TreeStore(private val database: DatabaseQueryManager) {
     val now = DateUtil.now()
     val touched = linkedSetOf<PositionKey>()
     for (insertion in moves) {
+      val createdAt = tree[insertion.from]?.outgoing?.get(insertion.move)?.createdAt ?: now
       val edge =
         Edge(
           from = insertion.from,
           move = insertion.move,
           to = insertion.to,
           isGood = insertion.isGood,
+          createdAt = createdAt,
           updatedAt = now,
         )
       tree.upsertEdge(edge, insertion.fromDepth)

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
@@ -322,6 +322,43 @@ class TestGraphSerializer {
   }
 
   @Test
+  fun edgeCreatedAtSurvivesRoundTrip() {
+    // DataMove equality ignores timestamps, so the round trip is asserted on the field itself.
+    val move =
+      DataMove(
+        startPos,
+        posAfterE4,
+        "e4",
+        isGood = true,
+        createdAt = instant1,
+        updatedAt = instant2,
+      )
+    val nodes =
+      listOf(
+        DataNode(
+          positionKey = startPos,
+          previousAndNextMoves = PreviousAndNextMoves(emptyList(), listOf(move)),
+          cardState = cardState(instant1),
+          depth = 0,
+          updatedAt = instant1,
+        ),
+        DataNode(
+          positionKey = posAfterE4,
+          previousAndNextMoves = PreviousAndNextMoves(listOf(move), emptyList()),
+          cardState = cardState(instant1),
+          depth = 1,
+          updatedAt = instant1,
+        ),
+      )
+
+    val result = GraphSerializer.deserialize(GraphSerializer.serialize(nodes))
+
+    val resultStart = result.first { it.positionKey == startPos }
+    resultStart.previousAndNextMoves.nextMoves["e4"]!!.createdAt shouldBe instant1
+    resultStart.previousAndNextMoves.nextMoves["e4"]!!.updatedAt shouldBe instant2
+  }
+
+  @Test
   fun invalidInputThrows() {
     shouldThrow<IllegalArgumentException> { GraphSerializer.deserialize("garbage") }
   }
@@ -339,27 +376,29 @@ class TestGraphSerializer {
 
   @Test
   fun edgeLineWithWrongColumnCountThrows() {
-    val input =
-      "1\t$startPos\t0\t2026-01-01T00:00:00Z\tnull\t0.0\t0.0\t0\t0\t2026-01-01T00:00:00Z\n\n1\t2"
+    val input = "${validNodeLine(1, startPos)}\n\n1\t2"
     shouldThrow<Exception> { GraphSerializer.deserialize(input) }
   }
 
   @Test
   fun edgeReferencingUnknownNodeThrows() {
     val input =
-      "1\t$startPos\t0\t2026-01-01T00:00:00Z\tnull\t0.0\t0.0\t0\t0\t2026-01-01T00:00:00Z\n\n" +
-        "1\t99\te4\t+\t2026-01-01T00:00:00Z"
+      "${validNodeLine(1, startPos)}\n\n" +
+        "1\t99\te4\t+\t2026-01-01T00:00:00Z\t2026-01-01T00:00:00Z"
     shouldThrow<IllegalArgumentException> { GraphSerializer.deserialize(input) }
   }
 
   @Test
   fun invalidIsGoodValueThrows() {
     val input =
-      "1\t$startPos\t0\t2026-01-01T00:00:00Z\tnull\t0.0\t0.0\t0\t0\t2026-01-01T00:00:00Z\n" +
-        "2\t$posAfterE4\t1\t2026-01-01T00:00:00Z\tnull\t0.0\t0.0\t0\t0\t2026-01-01T00:00:00Z\n\n" +
-        "1\t2\te4\tX\t2026-01-01T00:00:00Z"
+      "${validNodeLine(1, startPos)}\n${validNodeLine(2, posAfterE4)}\n\n" +
+        "1\t2\te4\tX\t2026-01-01T00:00:00Z\t2026-01-01T00:00:00Z"
     shouldThrow<IllegalArgumentException> { GraphSerializer.deserialize(input) }
   }
+
+  private fun validNodeLine(index: Int, positionKey: PositionKey): String =
+    "$index\t${positionKey.value}\t0\t2026-01-01T00:00:00Z\tnull\t0.0\t0.0\t0\t0\tNEW\t0\t" +
+      "2026-01-01T00:00:00Z"
 
   @Test
   fun emptyStringThrows() {

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestIntroductionOrder.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestIntroductionOrder.kt
@@ -1,0 +1,187 @@
+package proj.memorchess.axl.core.graph
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+import proj.memorchess.axl.core.data.DataMove
+import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.scheduling.CardStateFactory
+import proj.memorchess.axl.test_util.TestDatabaseQueryManager
+
+/**
+ * Tests for [OpeningTree.introductionOrder]: new positions are numbered depth first along a line,
+ * oldest branch first, so a whole line is introduced before the next branch starts.
+ */
+class TestIntroductionOrder {
+
+  private val start = PositionKey.START_POSITION
+  private val posA = PositionKey("posA b K")
+  private val posB = PositionKey("posB w K")
+  private val posC = PositionKey("posC b K")
+  private val posD = PositionKey("posD w K")
+
+  private val t1 = Instant.parse("2026-01-01T00:00:00Z")
+  private val t2 = Instant.parse("2026-01-02T00:00:00Z")
+
+  private fun move(from: PositionKey, san: String, to: PositionKey, createdAt: Instant) =
+    DataMove(
+      origin = from,
+      destination = to,
+      move = san,
+      isGood = true,
+      createdAt = createdAt,
+      updatedAt = createdAt,
+    )
+
+  private fun node(
+    key: PositionKey,
+    depth: Int,
+    incoming: List<DataMove>,
+    outgoing: List<DataMove>,
+  ) =
+    DataNode(
+      positionKey = key,
+      previousAndNextMoves = PreviousAndNextMoves(incoming, outgoing),
+      cardState = CardStateFactory.new(),
+      depth = depth,
+    )
+
+  private suspend fun loadGraph(vararg nodes: DataNode): OpeningTree {
+    val database = TestDatabaseQueryManager.empty()
+    database.insertNodes(*nodes)
+    val store = TreeStore(database)
+    store.load()
+    return store.current()
+  }
+
+  @Test
+  fun introductionOrderFollowsLineDepthFirst() = runTest {
+    val e4 = move(start, "e4", posA, t1)
+    val e5 = move(posA, "e5", posB, t1)
+    val tree =
+      loadGraph(
+        node(start, 0, emptyList(), listOf(e4)),
+        node(posA, 1, listOf(e4), listOf(e5)),
+        node(posB, 2, listOf(e5), emptyList()),
+      )
+    val order = tree.introductionOrder()
+    assertEquals(0, order[start])
+    assertEquals(1, order[posA])
+    assertEquals(2, order[posB])
+  }
+
+  @Test
+  fun introductionOrderServesFirstBranchFullyBeforeSecond() = runTest {
+    // Older branch: e4 then e5. Newer branch: d4 then d5. The whole e4 line must be numbered
+    // before the d4 line even though posC sits at the same depth as posA.
+    val e4 = move(start, "e4", posA, t1)
+    val e5 = move(posA, "e5", posB, t1)
+    val d4 = move(start, "d4", posC, t2)
+    val d5 = move(posC, "d5", posD, t2)
+    val tree =
+      loadGraph(
+        node(start, 0, emptyList(), listOf(e4, d4)),
+        node(posA, 1, listOf(e4), listOf(e5)),
+        node(posB, 2, listOf(e5), emptyList()),
+        node(posC, 1, listOf(d4), listOf(d5)),
+        node(posD, 2, listOf(d5), emptyList()),
+      )
+    val order = tree.introductionOrder()
+    assertEquals(0, order[start])
+    assertEquals(1, order[posA])
+    assertEquals(2, order[posB])
+    assertEquals(3, order[posC])
+    assertEquals(4, order[posD])
+  }
+
+  @Test
+  fun introductionOrderBreaksEqualCreatedAtBySanAlphabetically() = runTest {
+    val e4 = move(start, "e4", posA, t1)
+    val d4 = move(start, "d4", posC, t1)
+    val tree =
+      loadGraph(
+        node(start, 0, emptyList(), listOf(e4, d4)),
+        node(posA, 1, listOf(e4), emptyList()),
+        node(posC, 1, listOf(d4), emptyList()),
+      )
+    val order = tree.introductionOrder()
+    assertEquals(1, order[posC], "d4 sorts before e4 when both branches were created together")
+    assertEquals(2, order[posA])
+  }
+
+  @Test
+  fun introductionOrderIndexesTranspositionAtFirstVisit() = runTest {
+    // posB is reachable from both branches. It must get exactly one index, assigned while the
+    // older branch is being walked.
+    val e4 = move(start, "e4", posA, t1)
+    val viaA = move(posA, "c4", posB, t1)
+    val d4 = move(start, "d4", posC, t2)
+    val viaC = move(posC, "e4", posB, t2)
+    val tree =
+      loadGraph(
+        node(start, 0, emptyList(), listOf(e4, d4)),
+        node(posA, 1, listOf(e4), listOf(viaA)),
+        node(posC, 1, listOf(d4), listOf(viaC)),
+        node(posB, 2, listOf(viaA, viaC), emptyList()),
+      )
+    val order = tree.introductionOrder()
+    assertEquals(4, order.size)
+    assertEquals(2, order[posB], "transposition is numbered inside the branch visited first")
+    assertEquals(3, order[posC])
+  }
+
+  @Test
+  fun introductionOrderAppendsUnreachableNodesByDepthThenKey() = runTest {
+    val e4 = move(start, "e4", posA, t1)
+    val tree =
+      loadGraph(
+        node(start, 0, emptyList(), listOf(e4)),
+        node(posA, 1, listOf(e4), emptyList()),
+        // Orphans, not connected to the start position. posD is deeper than posC.
+        node(posD, 5, emptyList(), emptyList()),
+        node(posC, 3, emptyList(), emptyList()),
+      )
+    val order = tree.introductionOrder()
+    assertEquals(2, order[posC])
+    assertEquals(3, order[posD])
+  }
+
+  @Test
+  fun introductionOrderWithoutStartPositionFallsBackToDepthOrder() = runTest {
+    val tree =
+      loadGraph(node(posB, 2, emptyList(), emptyList()), node(posA, 1, emptyList(), emptyList()))
+    val order = tree.introductionOrder()
+    assertEquals(0, order[posA])
+    assertEquals(1, order[posB])
+  }
+
+  @Test
+  fun introductionOrderIgnoresDeletedEdges() = runTest {
+    val e4 = move(start, "e4", posA, t1).copy(isDeleted = true)
+    val d4 = move(start, "d4", posC, t2)
+    val database = TestDatabaseQueryManager.empty()
+    database.insertNodes(
+      node(start, 0, emptyList(), listOf(e4, d4)),
+      node(posA, 1, listOf(e4), emptyList()),
+      node(posC, 1, listOf(d4), emptyList()),
+    )
+    val store = TreeStore(database)
+    store.load()
+    val order = store.current().introductionOrder()
+    assertEquals(1, order[posC], "the deleted older branch must not be followed")
+    assertTrue(order.getValue(posA) > order.getValue(posC))
+  }
+
+  @Test
+  fun addMovePreservesCreatedAtOnReupsert() = runTest {
+    val store = TreeStore(TestDatabaseQueryManager.empty())
+    store.addMove(from = start, move = "e4", to = posA, isGood = null, fromDepth = 0)
+    val created = store.current().get(start)!!.outgoing.getValue("e4").createdAt
+    store.addMove(from = start, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    val afterReupsert = store.current().get(start)!!.outgoing.getValue("e4").createdAt
+    assertEquals(created, afterReupsert)
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestNavigationHistory.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestNavigationHistory.kt
@@ -14,9 +14,23 @@ class TestNavigationHistory {
   private val posA = PositionKey("posA b K")
   private val posB = PositionKey("posB w K")
   private val moveToA =
-    Edge(from = startPos, move = "e4", to = posA, isGood = true, updatedAt = instant)
+    Edge(
+      from = startPos,
+      move = "e4",
+      to = posA,
+      isGood = true,
+      createdAt = instant,
+      updatedAt = instant,
+    )
   private val moveToB =
-    Edge(from = posA, move = "e5", to = posB, isGood = true, updatedAt = instant)
+    Edge(
+      from = posA,
+      move = "e5",
+      to = posB,
+      isGood = true,
+      createdAt = instant,
+      updatedAt = instant,
+    )
 
   @Test
   fun pushThenBackReturnsOriginalPosition() {
@@ -59,7 +73,15 @@ class TestNavigationHistory {
     nav.back()
     // Push a different move — should clear forward stack
     val posC = PositionKey("posC b K")
-    val moveToC = Edge(from = startPos, move = "d4", to = posC, isGood = true, updatedAt = instant)
+    val moveToC =
+      Edge(
+        from = startPos,
+        move = "d4",
+        to = posC,
+        isGood = true,
+        createdAt = instant,
+        updatedAt = instant,
+      )
     nav.push(moveToC, posC)
     assertNull(nav.forward())
   }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
@@ -9,6 +9,8 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
+import proj.memorchess.axl.core.data.DataMove
+import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.date.DateUtil
 import proj.memorchess.axl.core.scheduling.CardPhase
@@ -132,6 +134,86 @@ class TestTrainingScheduler {
     store.updateCardState(posB, learningCard(now + 1.minutes))
     assertEquals(posB, scheduler.nextDue()?.positionKey)
   }
+
+  @Test
+  fun nextDueServesDueReviewCardsBeforeNewCards() = runTest {
+    val (store, scheduler) = newScheduler()
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    store.addMove(from = posA, move = "e5", to = posB, isGood = true, fromDepth = 1)
+    // startPos is a brand new card at depth 0; posA is a graduated review card due in the past at
+    // depth 1. The due review wins even though the new card is shallower.
+    store.updateCardState(posA, reviewCard(DateUtil.now() - 1.days))
+    assertEquals(posA, scheduler.nextDue()?.positionKey)
+  }
+
+  @Test
+  fun nextDuePicksNewCardsByIntroductionOrderNotDepth() = runTest {
+    // Older branch: the e4 line with trainable positions at depths 1 and 2. Newer branch: the d4
+    // line with a trainable position at depth 1. Once startPos and posA are no longer due, the
+    // remaining new cards are posB (depth 2, older line) and posC (depth 1, newer line). The
+    // older line continues before the newer branch starts, even though posC is shallower.
+    val t1 = Instant.parse("2026-01-01T00:00:00Z")
+    val t2 = Instant.parse("2026-01-02T00:00:00Z")
+    val endOfOldLine = PositionKey("endOld w K")
+    val endOfNewLine = PositionKey("endNew w K")
+    val e4 = dataMove(startPos, "e4", posA, t1)
+    val e5 = dataMove(posA, "e5", posB, t1)
+    val g3 = dataMove(posB, "g3", endOfOldLine, t1)
+    val d4 = dataMove(startPos, "d4", posC, t2)
+    val d5 = dataMove(posC, "d5", endOfNewLine, t2)
+    val database = TestDatabaseQueryManager.empty()
+    database.insertNodes(
+      dataNode(startPos, 0, emptyList(), listOf(e4, d4)),
+      dataNode(posA, 1, listOf(e4), listOf(e5)),
+      dataNode(posB, 2, listOf(e5), listOf(g3)),
+      dataNode(endOfOldLine, 3, listOf(g3), emptyList()),
+      dataNode(posC, 1, listOf(d4), listOf(d5)),
+      dataNode(endOfNewLine, 2, listOf(d5), emptyList()),
+    )
+    val store = TreeStore(database)
+    store.load()
+    val scheduler =
+      TrainingScheduler(store, Fsrs6SchedulingAlgorithm(), TimeZone.currentSystemDefault())
+    val now = DateUtil.now()
+    store.updateCardState(startPos, CardStateFactory.new(now + 5.days))
+    store.updateCardState(posA, CardStateFactory.new(now + 5.days))
+    assertEquals(posB, scheduler.nextDue()?.positionKey)
+  }
+
+  private fun dataMove(from: PositionKey, san: String, to: PositionKey, createdAt: Instant) =
+    DataMove(
+      origin = from,
+      destination = to,
+      move = san,
+      isGood = true,
+      createdAt = createdAt,
+      updatedAt = createdAt,
+    )
+
+  private fun dataNode(
+    key: PositionKey,
+    depth: Int,
+    incoming: List<DataMove>,
+    outgoing: List<DataMove>,
+  ) =
+    DataNode(
+      positionKey = key,
+      previousAndNextMoves = PreviousAndNextMoves(incoming, outgoing),
+      cardState = CardStateFactory.new(),
+      depth = depth,
+    )
+
+  private fun reviewCard(due: Instant): CardState =
+    CardState(
+      dueDate = due,
+      lastReview = due - 1.days,
+      stability = 1.0,
+      difficulty = 5.0,
+      reps = 1,
+      lapses = 0,
+      phase = CardPhase.REVIEW,
+      step = 0,
+    )
 
   private fun learningCard(due: Instant): CardState =
     CardState(

--- a/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestNodeWithMovesMapping.kt
+++ b/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestNodeWithMovesMapping.kt
@@ -38,6 +38,23 @@ class TestNodeWithMovesMapping {
   }
 
   @Test
+  fun moveCreatedAtSurvivesTheRoundTrip() {
+    val createdAt = Instant.parse("2026-05-01T08:00:00Z")
+    val move =
+      DataMove(
+        origin = PositionKey("posA b K"),
+        destination = PositionKey("posB w K"),
+        move = "e4",
+        isGood = true,
+        createdAt = createdAt,
+        updatedAt = due,
+      )
+    val roundTripped = MoveEntity.convertToEntity(move).toStoredMove()
+    roundTripped.createdAt shouldBe createdAt
+    roundTripped.updatedAt shouldBe due
+  }
+
+  @Test
   fun everyPhaseRoundTripsToItself() {
     for (phase in CardPhase.entries) {
       val card =

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/CustomDatabase.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/CustomDatabase.kt
@@ -13,7 +13,7 @@ import proj.memorchess.axl.core.data.explorer.ExplorerCacheEntity
 
 @Database(
   entities = [NodeEntity::class, MoveEntity::class, ExplorerCacheEntity::class],
-  version = 5,
+  version = 6,
   exportSchema = false,
 )
 @TypeConverters(DateConverters::class)

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/MoveEntity.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/MoveEntity.kt
@@ -34,6 +34,9 @@ data class MoveEntity(
   /** If true, the node is deleted. */
   val isDeleted: Boolean = false,
 
+  /** The date time at which the move was first added. */
+  val createdAt: Instant = DateUtil.now(),
+
   /** The date time of the last update. */
   val updatedAt: Instant = DateUtil.now(),
 ) {
@@ -46,6 +49,7 @@ data class MoveEntity(
       move,
       isGood,
       isDeleted,
+      createdAt,
       updatedAt,
     )
   }
@@ -63,6 +67,7 @@ data class MoveEntity(
         dataMove.move,
         isGood,
         dataMove.isDeleted,
+        dataMove.createdAt,
         dataMove.updatedAt,
       )
     }

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -46,6 +46,7 @@ private external interface JsMoveEntity : JsAny {
   var move: String
   var isGood: Boolean
   var isDeleted: Boolean
+  var createdAt: Double // epoch seconds (Double avoids Long→BigInt)
   var updatedAt: Double // epoch seconds (Double avoids Long→BigInt)
 }
 
@@ -81,6 +82,7 @@ private fun JsMoveEntity.toDataMove(): DataMove =
     move = move,
     isGood = isGood,
     isDeleted = isDeleted,
+    createdAt = Instant.fromEpochSeconds(createdAt.toLong()),
     updatedAt = Instant.fromEpochSeconds(updatedAt.toLong()),
   )
 
@@ -147,6 +149,7 @@ private fun DataMove.toJsMoveEntity(): JsMoveEntity {
     move = dataMove.move
     isGood = isGoodValue
     isDeleted = dataMove.isDeleted
+    createdAt = dataMove.createdAt.epochSeconds.toDouble()
     updatedAt = dataMove.updatedAt.epochSeconds.toDouble()
   }
 }
@@ -159,7 +162,7 @@ internal const val NODES_STORE = "nodes"
 internal const val MOVES_STORE = "moves"
 internal const val EXPLORER_CACHE_STORE = "explorerCache"
 internal const val DB_NAME = "memorchess"
-internal const val DB_VERSION = 4
+internal const val DB_VERSION = 5
 
 // ---------------------------------------------------------------------------
 // IndexedDB-backed DatabaseQueryManager


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Description

Closes #204

New cards are now introduced in line order, like Anki introduces new cards in deck order: depth first from the start position to the end of a line, then the next branch. Previously `TrainingScheduler` picked new cards by shallowest graph depth, so a freshly installed 50 move repertoire served all 50 new moves at once, scattered across lines.

### How

- `Edge` and `DataMove` carry a persisted `createdAt`. `TreeStore.addMove` preserves it across re-upserts, which matters because exploration re-upserts every edge it replays; without preservation, merely browsing a line would reshuffle the order.
- `OpeningTree.introductionOrder()`: deterministic DFS from the start position, siblings visited oldest `createdAt` first with move SAN as tiebreak. Transpositions are numbered at first visit; unreachable positions are appended by depth then key.
- `TrainingScheduler.nextDue()` tier 2 is split: due REVIEW cards first (by depth, unchanged), then NEW cards by introduction order.
- Schema: Room version 5 to 6, IndexedDB `DB_VERSION` 4 to 5 (destructive recreate, no migrations per project convention).

### Breaking change

`GraphSerializer` edge lines gain a sixth field (`createdAt`), so exports produced before this PR no longer import. Accepted: the app is pre-production and the serializer has no version header.

### Notes

- Order is stable across restarts and platforms because it derives from persisted `createdAt`, and it is independent of the repertoire feature (manually entered openings benefit equally).
- Pairs with #205 (daily limits): this PR decides which new card comes next, #205 decides how many.