### PR TITLE
feat(ui): read-only repertoire viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,14 @@ MemorChess (Anki Chess) is a Kotlin Multiplatform app for memorizing chess openi
 ./gradlew build
 
 # Run desktop (JVM)
-./gradlew :composeApp:run
+./gradlew :composeApp:jvmRun
 
 # Run tests
-./gradlew desktopTest                          # JVM/desktop tests
+./gradlew jvmTest                              # JVM/desktop tests
 ./gradlew :androidApp:connectedCheck           # Android instrumented tests
 
 # Run a single test class (desktop)
-./gradlew desktopTest --tests "proj.memorchess.axl.core.engine.graph.TestCache"
+./gradlew jvmTest --tests "proj.memorchess.axl.core.engine.graph.TestCache"
 
 # Code formatting (ktfmt, Google style)
 ./gradlew ktfmtCheck                           # Check formatting

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -197,14 +197,19 @@
   <string name="library_install_error_malformed_pgn">Ce fichier de répertoire n'a pas pu être lu : %1$s</string>
   <string name="library_install_error_import">Échec de l'import : %1$s</string>
   <string name="library_preview_question">Ajouter ce répertoire à vos ouvertures ? Les coups existants et leur historique d'entraînement sont conservés.</string>
+  <string name="library_view">Parcourir ce répertoire</string>
   <plurals name="library_move_count">
     <item quantity="one">%1$d coup</item>
     <item quantity="other">%1$d coups</item>
   </plurals>
+
+  <!-- Repertoire viewer -->
+  <string name="repertoire_view_not_found">Le répertoire \"%1$s\" n'est plus dans le catalogue.</string>
 
   <!-- Core toasts -->
   <string name="toast_no_previous_move">Aucun coup précédent.</string>
   <string name="toast_no_next_move">Aucun coup suivant.</string>
   <string name="toast_saved">Enregistré</string>
   <string name="toast_deleted">Supprimé</string>
+  <string name="toast_not_in_repertoire">Ce coup ne fait pas partie de ce répertoire.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -197,14 +197,19 @@
   <string name="library_install_error_malformed_pgn">This repertoire file could not be read: %1$s</string>
   <string name="library_install_error_import">Import failed: %1$s</string>
   <string name="library_preview_question">Add this repertoire to your openings? Existing moves and their training history are kept.</string>
+  <string name="library_view">Browse this repertoire</string>
   <plurals name="library_move_count">
     <item quantity="one">%1$d move</item>
     <item quantity="other">%1$d moves</item>
   </plurals>
+
+  <!-- Repertoire viewer -->
+  <string name="repertoire_view_not_found">Repertoire \"%1$s\" is not in the catalog anymore.</string>
 
   <!-- Core toasts -->
   <string name="toast_no_previous_move">No previous move.</string>
   <string name="toast_no_next_move">No next move.</string>
   <string name="toast_saved">Saved</string>
   <string name="toast_deleted">Deleted</string>
+  <string name="toast_not_in_repertoire">That move is not in this repertoire.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -1,0 +1,111 @@
+package proj.memorchess.axl.core.data
+
+import kotlin.time.Instant
+import proj.memorchess.axl.core.graph.DeleteMode
+import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+
+/**
+ * In memory [DatabaseQueryManager] with no persistence at all.
+ *
+ * It backs throwaway [proj.memorchess.axl.core.graph.TreeStore] instances that exist only for the
+ * lifetime of a single screen, such as the read only repertoire viewer which rebuilds an isolated
+ * opening graph from a downloaded PGN every time it opens. Nothing here touches Room or IndexedDB,
+ * so it works identically on every target and leaves the user's real graph untouched.
+ *
+ * Behaviour mirrors the platform implementations closely enough for [TreeStore]: hard deletes
+ * physically remove rows and any incident move, soft deletes flip the [DataNode.isDeleted] flag.
+ */
+class InMemoryDatabaseQueryManager : DatabaseQueryManager {
+
+  private val nodes = mutableMapOf<PositionKey, DataNode>()
+
+  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> =
+    nodes.values.filter { withDeletedOnes || !it.isDeleted }.toList()
+
+  override suspend fun getPosition(positionKey: PositionKey): DataNode? =
+    nodes[positionKey]?.takeIf { !it.isDeleted }
+
+  override suspend fun insertNodes(vararg positions: DataNode) {
+    positions.forEach { nodes[it.positionKey] = it }
+  }
+
+  override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) {
+    val node = nodes[position] ?: return
+    when (mode) {
+      DeleteMode.HARD -> {
+        nodes.remove(position)
+        // Drop any move that pointed to or came from the removed position.
+        for ((key, other) in nodes.toMap()) {
+          val moves = other.previousAndNextMoves
+          val previousMoves = moves.previousMoves.values.filter { it.origin != position }
+          val nextMoves = moves.nextMoves.values.filter { it.destination != position }
+          if (
+            previousMoves.size != moves.previousMoves.size || nextMoves.size != moves.nextMoves.size
+          ) {
+            nodes[key] =
+              other.copy(previousAndNextMoves = PreviousAndNextMoves(previousMoves, nextMoves))
+          }
+        }
+      }
+      DeleteMode.SOFT -> nodes[position] = node.copy(isDeleted = true)
+    }
+  }
+
+  override suspend fun deleteMove(origin: PositionKey, move: String, mode: DeleteMode) {
+    val node = nodes[origin] ?: return
+    val edge = node.previousAndNextMoves.nextMoves[move] ?: return
+    val destination = edge.destination
+    nodes[origin] =
+      node.copy(previousAndNextMoves = node.previousAndNextMoves.withoutNext(move, mode))
+    val destinationNode = nodes[destination] ?: return
+    nodes[destination] =
+      destinationNode.copy(
+        previousAndNextMoves = destinationNode.previousAndNextMoves.withoutPrevious(move, mode)
+      )
+  }
+
+  override suspend fun eraseAll() {
+    nodes.clear()
+  }
+
+  override suspend fun getLastUpdate(): Instant? {
+    val nodeMax = nodes.values.maxOfOrNull { it.updatedAt }
+    val moveMax =
+      nodes.values
+        .flatMap {
+          (it.previousAndNextMoves.previousMoves + it.previousAndNextMoves.nextMoves).values
+        }
+        .maxOfOrNull { it.updatedAt }
+    return when {
+      nodeMax == null -> moveMax
+      moveMax == null -> nodeMax
+      else -> maxOf(nodeMax, moveMax)
+    }
+  }
+
+  private fun PreviousAndNextMoves.withoutNext(
+    move: String,
+    mode: DeleteMode,
+  ): PreviousAndNextMoves =
+    PreviousAndNextMoves(previousMoves.values, removeOrFlag(nextMoves, move, mode))
+
+  private fun PreviousAndNextMoves.withoutPrevious(
+    move: String,
+    mode: DeleteMode,
+  ): PreviousAndNextMoves =
+    PreviousAndNextMoves(removeOrFlag(previousMoves, move, mode), nextMoves.values)
+
+  private fun removeOrFlag(
+    moves: Map<String, DataMove>,
+    move: String,
+    mode: DeleteMode,
+  ): List<DataMove> =
+    moves.values.mapNotNull {
+      if (it.move != move) it
+      else
+        when (mode) {
+          DeleteMode.HARD -> null
+          DeleteMode.SOFT -> it.copy(isDeleted = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -14,10 +14,14 @@ import proj.memorchess.axl.core.graph.PreviousAndNextMoves
  *
  * Behaviour mirrors the platform implementations closely enough for [TreeStore]: hard deletes
  * physically remove rows and any incident move, soft deletes flip the [DataNode.isDeleted] flag.
+ *
+ * Open so tests can subclass it with prefilled-opening fixtures instead of reimplementing the
+ * storage; subclasses read and seed the graph through [nodes].
  */
-class InMemoryDatabaseQueryManager : DatabaseQueryManager {
+open class InMemoryDatabaseQueryManager : DatabaseQueryManager {
 
-  private val nodes = mutableMapOf<PositionKey, DataNode>()
+  /** Backing store, keyed by position. Soft-deleted nodes stay here with their flag set. */
+  protected val nodes: MutableMap<PositionKey, DataNode> = mutableMapOf()
 
   override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> =
     nodes.values.filter { withDeletedOnes || !it.isDeleted }.toList()

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -72,20 +72,13 @@ open class InMemoryDatabaseQueryManager : DatabaseQueryManager {
     nodes.clear()
   }
 
-  override suspend fun getLastUpdate(): Instant? {
-    val nodeMax = nodes.values.maxOfOrNull { it.updatedAt }
-    val moveMax =
-      nodes.values
-        .flatMap {
-          (it.previousAndNextMoves.previousMoves + it.previousAndNextMoves.nextMoves).values
-        }
-        .maxOfOrNull { it.updatedAt }
-    return when {
-      nodeMax == null -> moveMax
-      moveMax == null -> nodeMax
-      else -> maxOf(nodeMax, moveMax)
-    }
-  }
+  override suspend fun getLastUpdate(): Instant? =
+    nodes.values
+      .flatMap { node ->
+        val moves = node.previousAndNextMoves
+        listOf(node.updatedAt) + (moves.previousMoves + moves.nextMoves).values.map { it.updatedAt }
+      }
+      .maxOrNull()
 
   private fun PreviousAndNextMoves.withoutNext(
     move: String,

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/interactions/RepertoireExplorer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/interactions/RepertoireExplorer.kt
@@ -35,7 +35,8 @@ class RepertoireExplorer private constructor(treeStore: TreeStore) :
       return
     }
     navigation.push(edge, edge.to)
-    state = treeStore.current().computeState(navigation.current, navigation.arrivedVia?.from)
+    // After the push, navigation.arrivedVia is exactly this edge, so edge.from is the parent.
+    state = treeStore.current().computeState(navigation.current, edge.from)
     callCallBacks()
   }
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/interactions/RepertoireExplorer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/interactions/RepertoireExplorer.kt
@@ -1,0 +1,57 @@
+package proj.memorchess.axl.core.interactions
+
+import memorchess.composeapp.generated.resources.Res
+import memorchess.composeapp.generated.resources.toast_not_in_repertoire
+import proj.memorchess.axl.core.data.InMemoryDatabaseQueryManager
+import proj.memorchess.axl.core.engine.GameEngine
+import proj.memorchess.axl.core.graph.TreeStore
+import proj.memorchess.axl.core.pgn.PgnGame
+import proj.memorchess.axl.core.pgn.PgnImporter
+
+/**
+ * Read only navigator over the lines of a single repertoire.
+ *
+ * Unlike [LinesExplorer], which mutates the user's persisted opening graph, this explorer walks a
+ * throwaway [TreeStore] built from a downloaded PGN (see [build]) and never writes anything back.
+ * Only moves that exist in that PGN can be played: an off book move is rejected and the board snaps
+ * back to the position it came from. Back / forward / reset and the next move list are inherited
+ * from [LinesExplorer] and operate on the transient graph, which contains exactly the repertoire's
+ * moves.
+ *
+ * @constructor Wraps an already populated transient [treeStore]. Use [build] to create one from
+ *   PGN.
+ */
+class RepertoireExplorer private constructor(treeStore: TreeStore) :
+  LinesExplorer(position = null, treeStore = treeStore) {
+
+  override suspend fun afterPlayMove(move: String) {
+    val origin = navigation.current
+    val edge = treeStore.current().get(origin)?.outgoing?.get(move)
+    if (edge == null) {
+      // Legal chess move but not part of this repertoire: undo it and stay put.
+      engine = GameEngine(origin)
+      toastRenderer.info(Res.string.toast_not_in_repertoire)
+      callCallBacks(false)
+      return
+    }
+    navigation.push(edge, edge.to)
+    state = treeStore.current().computeState(navigation.current, navigation.arrivedVia?.from)
+    callCallBacks()
+  }
+
+  companion object {
+    /**
+     * Builds an explorer over the lines of [games], replayed into a fresh in memory graph.
+     *
+     * @param games Parsed repertoire games, normally from
+     *   [proj.memorchess.axl.core.data.repertoire.RepertoireCatalogClient.fetchPgn].
+     * @throws proj.memorchess.axl.core.pgn.PgnImportException if any move of any variation is
+     *   illegal.
+     */
+    suspend fun build(games: List<PgnGame>): RepertoireExplorer {
+      val treeStore = TreeStore(InMemoryDatabaseQueryManager())
+      PgnImporter(treeStore).import(games)
+      return RepertoireExplorer(treeStore)
+    }
+  }
+}

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/explore/ExploreCtrlBar.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/explore/ExploreCtrlBar.kt
@@ -67,6 +67,8 @@ data class ExploreCtrlBarActions(
  * @param evalEnabled `true` if the eval bar is currently enabled (drives Primary vs Default style).
  * @param playerTurnWhite `true` when it is white's move, used for the central player-turn pill.
  * @param modifier External modifier applied to the row.
+ * @param showSaveDelete `true` to render the save and delete buttons; `false` hides them for read
+ *   only contexts such as the repertoire viewer.
  */
 @Composable
 fun ExploreCtrlBar(
@@ -74,6 +76,7 @@ fun ExploreCtrlBar(
   evalEnabled: Boolean,
   playerTurnWhite: Boolean,
   modifier: Modifier = Modifier,
+  showSaveDelete: Boolean = true,
 ) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
@@ -131,17 +134,23 @@ fun ExploreCtrlBar(
     // Filler — pushes save/delete to the right.
     Box(modifier = Modifier.weight(1f).fillMaxWidth())
 
-    KineticButton(onClick = actions.onSave, style = KineticButtonStyle.Primary, iconOnly = true) {
-      Icon(
-        FeatherIcons.Save,
-        contentDescription = stringResource(Res.string.description_board_save),
-      )
-    }
-    KineticButton(onClick = actions.onDelete, style = KineticButtonStyle.Danger, iconOnly = true) {
-      Icon(
-        FeatherIcons.Trash,
-        contentDescription = stringResource(Res.string.description_board_delete),
-      )
+    if (showSaveDelete) {
+      KineticButton(onClick = actions.onSave, style = KineticButtonStyle.Primary, iconOnly = true) {
+        Icon(
+          FeatherIcons.Save,
+          contentDescription = stringResource(Res.string.description_board_save),
+        )
+      }
+      KineticButton(
+        onClick = actions.onDelete,
+        style = KineticButtonStyle.Danger,
+        iconOnly = true,
+      ) {
+        Icon(
+          FeatherIcons.Trash,
+          contentDescription = stringResource(Res.string.description_board_delete),
+        )
+      }
     }
   }
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/Explore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/Explore.kt
@@ -23,7 +23,6 @@ import org.jetbrains.compose.resources.pluralStringResource
 import org.koin.compose.koinInject
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.data.explorer.CachedExplorer
-import proj.memorchess.axl.core.data.explorer.ExplorerViewModel
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.core.interactions.LinesExplorer
 import proj.memorchess.axl.ui.components.loading.LoadingWidget
@@ -50,18 +49,7 @@ fun Explore(
       val initialPosition = extractInitialPosition(position, treeStore)
       val linesExplorer = remember { LinesExplorer(initialPosition, treeStore) }
       val coroutineScope = rememberCoroutineScope()
-      val explorerViewModel =
-        remember(cachedExplorer, coroutineScope) {
-          ExplorerViewModel(cachedExplorer, coroutineScope)
-        }
-
-      // Seed the view model with the starting FEN and refresh it on every move.
-      LaunchedEffect(linesExplorer) { explorerViewModel.setFen(linesExplorer.engine.toFen().value) }
-      remember {
-        linesExplorer.registerCallBack {
-          explorerViewModel.setFen(linesExplorer.engine.toFen().value)
-        }
-      }
+      val explorerViewModel = rememberExplorerViewModel(linesExplorer, cachedExplorer)
 
       val deletionConfirmationDialog = remember {
         ConfirmationDialog(okText = Res.string.dialog_delete)

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
@@ -69,6 +69,18 @@ import proj.memorchess.axl.ui.layout.explore.PortraitExploreLayout
 import proj.memorchess.axl.ui.theme.LocalKineticPalette
 
 /**
+ * Read-only configuration for [ExplorerContent]. When non-null the explorer becomes a viewer: the
+ * Save and Delete controls and the node save-state indicators are hidden because the underlying
+ * graph is a throwaway copy that nothing can mutate.
+ *
+ * @property initialInverted Initial board orientation; `true` opens from black's side (used to show
+ *   a black repertoire from black's perspective).
+ * @property cornerTag Overrides the board shell corner tag, since the node save-state label is not
+ *   meaningful in read-only mode (the repertoire name is shown instead).
+ */
+data class ExplorerViewerMode(val initialInverted: Boolean = false, val cornerTag: String? = null)
+
+/**
  * Shared explorer content relying on a [LinesExplorer].
  *
  * @param explorer The explorer instance.
@@ -76,13 +88,7 @@ import proj.memorchess.axl.ui.theme.LocalKineticPalette
  * @param onSave Invoked when the Kinetic control bar Save button is tapped.
  * @param onDelete Invoked when the Kinetic control bar Delete button is tapped.
  * @param header Optional header content rendered above the layout (legacy).
- * @param readOnly When `true`, the page is a viewer: the save and delete controls and the node
- *   save-state indicators are hidden. Used by the repertoire viewer, where the graph is a throwaway
- *   copy of a PGN and nothing can be mutated.
- * @param initialInverted Initial board orientation; `true` shows the board from black's side. Used
- *   to open a black repertoire from black's perspective.
- * @param cornerTag When non-null, overrides the board shell corner tag (the node save-state label
- *   is not meaningful in read-only mode, so the repertoire name is shown instead).
+ * @param viewerMode When non-null, renders the read-only viewer variant; see [ExplorerViewerMode].
  */
 @Composable
 fun ExplorerContent(
@@ -91,11 +97,10 @@ fun ExplorerContent(
   onSave: () -> Unit,
   onDelete: () -> Unit,
   header: @Composable () -> Unit = {},
-  readOnly: Boolean = false,
-  initialInverted: Boolean = false,
-  cornerTag: String? = null,
+  viewerMode: ExplorerViewerMode? = null,
 ) {
-  var inverted by remember { mutableStateOf(initialInverted) }
+  val readOnly = viewerMode != null
+  var inverted by remember { mutableStateOf(viewerMode?.initialInverted ?: false) }
   val coroutineScope = rememberCoroutineScope()
   val nextMoves = remember { mutableStateListOf(*explorer.getNextMoves().toTypedArray()) }
   var evalBarEnabled by remember { mutableStateOf(EVAL_BAR_ENABLED_SETTING.getValue()) }
@@ -135,7 +140,8 @@ fun ExplorerContent(
   // so this reactively recomposes when the user navigates, saves, or deletes.
   val palette = LocalKineticPalette.current
   val nodeState = explorer.state
-  val cornerTagLabel = if (readOnly) cornerTag else stringResource(nodeStateLabel(nodeState))
+  val cornerTagLabel =
+    if (readOnly) viewerMode?.cornerTag else stringResource(nodeStateLabel(nodeState))
   val cornerTagColor = if (readOnly) palette.ink2 else nodeStateColor(nodeState, palette)
 
   DisposableEffect(Unit) { onDispose { evaluator?.close() } }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
@@ -41,6 +41,7 @@ import org.jetbrains.compose.resources.stringResource
 import proj.memorchess.axl.core.config.BEST_MOVE_ARROW_ENABLED_SETTING
 import proj.memorchess.axl.core.config.ENGINE_MAX_DEPTH_SETTING
 import proj.memorchess.axl.core.config.EVAL_BAR_ENABLED_SETTING
+import proj.memorchess.axl.core.data.explorer.CachedExplorer
 import proj.memorchess.axl.core.data.explorer.ExplorerViewModel
 import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.core.engine.PieceKind
@@ -79,6 +80,27 @@ import proj.memorchess.axl.ui.theme.LocalKineticPalette
  *   meaningful in read-only mode (the repertoire name is shown instead).
  */
 data class ExplorerViewerMode(val initialInverted: Boolean = false, val cornerTag: String? = null)
+
+/**
+ * Creates an [ExplorerViewModel] bound to [explorer]: seeds it with the explorer's current FEN and
+ * refreshes it on every move. Shared by the free-exploration page and the read-only repertoire
+ * viewer, which wire the Lichess explorer panels identically.
+ *
+ * @param explorer The explorer whose position drives the opening explorer panels.
+ * @param cachedExplorer Backing data source for the returned [ExplorerViewModel].
+ */
+@Composable
+internal fun rememberExplorerViewModel(
+  explorer: LinesExplorer,
+  cachedExplorer: CachedExplorer,
+): ExplorerViewModel {
+  val coroutineScope = rememberCoroutineScope()
+  val explorerViewModel =
+    remember(cachedExplorer, coroutineScope) { ExplorerViewModel(cachedExplorer, coroutineScope) }
+  LaunchedEffect(explorer) { explorerViewModel.setFen(explorer.engine.toFen().value) }
+  remember { explorer.registerCallBack { explorerViewModel.setFen(explorer.engine.toFen().value) } }
+  return explorerViewModel
+}
 
 /**
  * Shared explorer content relying on a [LinesExplorer].

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
@@ -76,6 +76,13 @@ import proj.memorchess.axl.ui.theme.LocalKineticPalette
  * @param onSave Invoked when the Kinetic control bar Save button is tapped.
  * @param onDelete Invoked when the Kinetic control bar Delete button is tapped.
  * @param header Optional header content rendered above the layout (legacy).
+ * @param readOnly When `true`, the page is a viewer: the save and delete controls and the node
+ *   save-state indicators are hidden. Used by the repertoire viewer, where the graph is a throwaway
+ *   copy of a PGN and nothing can be mutated.
+ * @param initialInverted Initial board orientation; `true` shows the board from black's side. Used
+ *   to open a black repertoire from black's perspective.
+ * @param cornerTag When non-null, overrides the board shell corner tag (the node save-state label
+ *   is not meaningful in read-only mode, so the repertoire name is shown instead).
  */
 @Composable
 fun ExplorerContent(
@@ -84,8 +91,11 @@ fun ExplorerContent(
   onSave: () -> Unit,
   onDelete: () -> Unit,
   header: @Composable () -> Unit = {},
+  readOnly: Boolean = false,
+  initialInverted: Boolean = false,
+  cornerTag: String? = null,
 ) {
-  var inverted by remember { mutableStateOf(false) }
+  var inverted by remember { mutableStateOf(initialInverted) }
   val coroutineScope = rememberCoroutineScope()
   val nextMoves = remember { mutableStateListOf(*explorer.getNextMoves().toTypedArray()) }
   var evalBarEnabled by remember { mutableStateOf(EVAL_BAR_ENABLED_SETTING.getValue()) }
@@ -125,8 +135,8 @@ fun ExplorerContent(
   // so this reactively recomposes when the user navigates, saves, or deletes.
   val palette = LocalKineticPalette.current
   val nodeState = explorer.state
-  val cornerTagLabel = stringResource(nodeStateLabel(nodeState))
-  val cornerTagColor = nodeStateColor(nodeState, palette)
+  val cornerTagLabel = if (readOnly) cornerTag else stringResource(nodeStateLabel(nodeState))
+  val cornerTagColor = if (readOnly) palette.ink2 else nodeStateColor(nodeState, palette)
 
   DisposableEffect(Unit) { onDispose { evaluator?.close() } }
 
@@ -159,7 +169,7 @@ fun ExplorerContent(
         }
       },
       playerTurnIndicator = { PlayerTurnIndicator(explorer) },
-      stateIndicators = { StateIndicator(it, explorer.state) },
+      stateIndicators = { if (!readOnly) StateIndicator(it, explorer.state) },
       evaluationPanel = {
         if (evalBarEnabled) {
           EvaluationBar(evaluation = evaluation, currentDepth = currentDepth, modifier = it)
@@ -227,6 +237,7 @@ fun ExplorerContent(
             ),
           evalEnabled = evalBarEnabled,
           playerTurnWhite = playerTurnWhite,
+          showSaveDelete = !readOnly,
         )
       },
       sideInfo = { sideModifier ->

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/ExplorerContent.kt
@@ -141,7 +141,7 @@ fun ExplorerContent(
   val palette = LocalKineticPalette.current
   val nodeState = explorer.state
   val cornerTagLabel =
-    if (readOnly) viewerMode?.cornerTag else stringResource(nodeStateLabel(nodeState))
+    if (viewerMode != null) viewerMode.cornerTag else stringResource(nodeStateLabel(nodeState))
   val cornerTagColor = if (readOnly) palette.ink2 else nodeStateColor(nodeState, palette)
 
   DisposableEffect(Unit) { onDispose { evaluator?.close() } }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
@@ -123,10 +123,13 @@ fun RepertoireLibrary(
     catalogState = catalogState,
     installStates = installStates,
     previewStates = previewStates,
-    onInstall = viewModel::install,
-    onPreviewRequest = viewModel::requestPreview,
-    onRetry = viewModel::refresh,
-    onView = { descriptor -> navigator.navigateTo(Route.RepertoireViewRoute(descriptor.id)) },
+    actions =
+      RepertoireLibraryActions(
+        onInstall = viewModel::install,
+        onPreviewRequest = viewModel::requestPreview,
+        onRetry = viewModel::refresh,
+        onView = { descriptor -> navigator.navigateTo(Route.RepertoireViewRoute(descriptor.id)) },
+      ),
     modifier = Modifier.fillMaxSize().testTag(Route.LibraryRoute.getLabel()),
   )
 }
@@ -139,6 +142,22 @@ private fun RepertoireColor.toPlayer(): Player =
   }
 
 /**
+ * User actions raised by [RepertoireLibraryContent], grouped so the content stays within the
+ * parameter budget.
+ *
+ * @property onInstall Install (or reinstall) the given repertoire into the opening graph.
+ * @property onPreviewRequest Request the move-overlap preview for the given repertoire.
+ * @property onRetry Retry loading the catalog after a failure.
+ * @property onView Open the read-only viewer for the given repertoire.
+ */
+internal data class RepertoireLibraryActions(
+  val onInstall: (RepertoireDescriptor) -> Unit,
+  val onPreviewRequest: (RepertoireDescriptor) -> Unit,
+  val onRetry: () -> Unit,
+  val onView: (RepertoireDescriptor) -> Unit = {},
+)
+
+/**
  * Stateless rendering of the library page. Split out from [RepertoireLibrary] so tests can drive
  * each [LibraryCatalogState] and [RepertoireInstallState] without standing up a full view model.
  */
@@ -147,11 +166,8 @@ internal fun RepertoireLibraryContent(
   catalogState: LibraryCatalogState,
   installStates: Map<String, RepertoireInstallState>,
   previewStates: Map<String, RepertoirePreviewState>,
-  onInstall: (RepertoireDescriptor) -> Unit,
-  onPreviewRequest: (RepertoireDescriptor) -> Unit,
-  onRetry: () -> Unit,
+  actions: RepertoireLibraryActions,
   modifier: Modifier = Modifier,
-  onView: (RepertoireDescriptor) -> Unit = {},
 ) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
@@ -180,29 +196,29 @@ internal fun RepertoireLibraryContent(
       is LibraryCatalogState.NetworkError ->
         CatalogError(
           message = stringResource(Res.string.library_error_network, catalogState.message),
-          onRetry = onRetry,
+          onRetry = actions.onRetry,
         )
       is LibraryCatalogState.HttpError ->
         CatalogError(
           message = stringResource(Res.string.library_error_http, catalogState.status),
-          onRetry = onRetry,
+          onRetry = actions.onRetry,
         )
       is LibraryCatalogState.MalformedManifest ->
         CatalogError(
           message = stringResource(Res.string.library_error_malformed, catalogState.message),
-          onRetry = onRetry,
+          onRetry = actions.onRetry,
         )
       is LibraryCatalogState.Loaded ->
         CatalogList(
           state = catalogState,
           installStates = installStates,
           onInstallRequest = { descriptor ->
-            onPreviewRequest(descriptor)
-            previewDialog.show(confirm = { onInstall(descriptor) }) {
+            actions.onPreviewRequest(descriptor)
+            previewDialog.show(confirm = { actions.onInstall(descriptor) }) {
               PreviewDialogContent(descriptor, latestPreviewStates.value[descriptor.id])
             }
           },
-          onView = onView,
+          onView = actions.onView,
         )
     }
   }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -23,6 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import compose.icons.FeatherIcons
+import compose.icons.feathericons.Eye
 import memorchess.composeapp.generated.resources.Res
 import memorchess.composeapp.generated.resources.library_color_black
 import memorchess.composeapp.generated.resources.library_color_white
@@ -45,6 +48,7 @@ import memorchess.composeapp.generated.resources.library_retry
 import memorchess.composeapp.generated.resources.library_stale_hint
 import memorchess.composeapp.generated.resources.library_subtitle
 import memorchess.composeapp.generated.resources.library_title
+import memorchess.composeapp.generated.resources.library_view
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -63,6 +67,7 @@ import proj.memorchess.axl.ui.components.buttons.KineticButton
 import proj.memorchess.axl.ui.components.buttons.KineticButtonLabel
 import proj.memorchess.axl.ui.components.buttons.KineticButtonStyle
 import proj.memorchess.axl.ui.components.popup.ConfirmationDialog
+import proj.memorchess.axl.ui.pages.navigation.LocalNavigator
 import proj.memorchess.axl.ui.pages.navigation.Route
 import proj.memorchess.axl.ui.theme.LocalKineticPalette
 import proj.memorchess.axl.ui.theme.LocalKineticTypography
@@ -100,11 +105,13 @@ fun RepertoireLibrary(
     }
   val catalogState by viewModel.catalogState.collectAsState()
   val installStates by viewModel.installStates.collectAsState()
+  val navigator = LocalNavigator.current
   RepertoireLibraryContent(
     catalogState = catalogState,
     installStates = installStates,
     onInstall = viewModel::install,
     onRetry = viewModel::refresh,
+    onView = { descriptor -> navigator.navigateTo(Route.RepertoireViewRoute(descriptor.id)) },
     modifier = Modifier.fillMaxSize().testTag(Route.LibraryRoute.getLabel()),
   )
 }
@@ -120,6 +127,7 @@ internal fun RepertoireLibraryContent(
   onInstall: (RepertoireDescriptor) -> Unit,
   onRetry: () -> Unit,
   modifier: Modifier = Modifier,
+  onView: (RepertoireDescriptor) -> Unit = {},
 ) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
@@ -166,6 +174,7 @@ internal fun RepertoireLibraryContent(
               PreviewDialogContent(descriptor)
             }
           },
+          onView = onView,
         )
     }
   }
@@ -193,6 +202,7 @@ private fun CatalogList(
   state: LibraryCatalogState.Loaded,
   installStates: Map<String, RepertoireInstallState>,
   onInstallRequest: (RepertoireDescriptor) -> Unit,
+  onView: (RepertoireDescriptor) -> Unit,
 ) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
@@ -220,6 +230,7 @@ private fun CatalogList(
             descriptor = descriptor,
             installState = installStates[descriptor.id] ?: RepertoireInstallState.NotInstalled,
             onInstallRequest = { onInstallRequest(descriptor) },
+            onView = { onView(descriptor) },
           )
         }
       }
@@ -236,6 +247,7 @@ private fun RepertoireCard(
   descriptor: RepertoireDescriptor,
   installState: RepertoireInstallState,
   onInstallRequest: () -> Unit,
+  onView: () -> Unit,
 ) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
@@ -261,6 +273,16 @@ private fun RepertoireCard(
       ColorTag(descriptor.color)
       if (installState is RepertoireInstallState.Installed) {
         InstalledBadge()
+      }
+      KineticButton(
+        onClick = onView,
+        iconOnly = true,
+        modifier = Modifier.testTag("$TEST_TAG_CARD:${descriptor.id}:view"),
+      ) {
+        Icon(
+          imageVector = FeatherIcons.Eye,
+          contentDescription = stringResource(Res.string.library_view),
+        )
       }
     }
     Text(text = descriptor.description, style = typography.bodySm.copy(color = palette.ink3))

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
@@ -109,9 +109,11 @@ private fun RepertoireViewReady(
     explorerViewModel = explorerViewModel,
     onSave = {},
     onDelete = {},
-    readOnly = true,
-    initialInverted = descriptor.color == RepertoireColor.BLACK,
-    cornerTag = descriptor.name,
+    viewerMode =
+      ExplorerViewerMode(
+        initialInverted = descriptor.color == RepertoireColor.BLACK,
+        cornerTag = descriptor.name,
+      ),
   )
 }
 
@@ -166,7 +168,10 @@ private suspend fun loadRepertoire(
         return RepertoireViewState.Error(RepertoireViewError.Http(manifest.status))
       is CachedManifestResult.MalformedManifest ->
         return RepertoireViewState.Error(RepertoireViewError.MalformedManifest(manifest.message))
-    } ?: return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
+    }
+  if (descriptor == null) {
+    return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
+  }
 
   val games =
     when (val result = client.fetchPgn(descriptor.file)) {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
@@ -1,0 +1,226 @@
+package proj.memorchess.axl.ui.pages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import memorchess.composeapp.generated.resources.Res
+import memorchess.composeapp.generated.resources.library_error_http
+import memorchess.composeapp.generated.resources.library_error_malformed
+import memorchess.composeapp.generated.resources.library_error_network
+import memorchess.composeapp.generated.resources.library_install_error_import
+import memorchess.composeapp.generated.resources.library_install_error_malformed_pgn
+import memorchess.composeapp.generated.resources.library_retry
+import memorchess.composeapp.generated.resources.repertoire_view_not_found
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+import proj.memorchess.axl.core.data.explorer.CachedExplorer
+import proj.memorchess.axl.core.data.explorer.ExplorerViewModel
+import proj.memorchess.axl.core.data.repertoire.CachedManifestResult
+import proj.memorchess.axl.core.data.repertoire.CachedRepertoireCatalog
+import proj.memorchess.axl.core.data.repertoire.CatalogResult
+import proj.memorchess.axl.core.data.repertoire.RepertoireCatalogClient
+import proj.memorchess.axl.core.data.repertoire.RepertoireColor
+import proj.memorchess.axl.core.data.repertoire.RepertoireDescriptor
+import proj.memorchess.axl.core.interactions.RepertoireExplorer
+import proj.memorchess.axl.core.pgn.PgnImportException
+import proj.memorchess.axl.ui.components.buttons.KineticButton
+import proj.memorchess.axl.ui.components.buttons.KineticButtonLabel
+import proj.memorchess.axl.ui.theme.LocalKineticPalette
+import proj.memorchess.axl.ui.theme.LocalKineticTypography
+
+/** Test tag identifying the repertoire viewer page root. */
+const val REPERTOIRE_VIEW_TEST_TAG = "repertoire_view"
+
+/**
+ * Read only viewer for a single catalog repertoire.
+ *
+ * Fetches the repertoire's PGN every time it opens (no offline copy is kept), replays it into a
+ * throwaway opening graph and lets the user navigate it on a board through [ExplorerContent] in
+ * read-only mode: no save or delete, and only moves present in the PGN can be played. Works for any
+ * repertoire whether or not it is installed, so it doubles as a preview before install.
+ *
+ * @param repertoireId Id of the repertoire to display, as listed in the catalog manifest.
+ * @param catalog Resolves the descriptor (name, color, PGN path) from the manifest.
+ * @param client Downloads and parses the PGN.
+ * @param cachedExplorer Backs the Lichess opening explorer panels of [ExplorerContent].
+ */
+@Composable
+fun RepertoireView(
+  repertoireId: String,
+  catalog: CachedRepertoireCatalog = koinInject(),
+  client: RepertoireCatalogClient = koinInject(),
+  cachedExplorer: CachedExplorer = koinInject(),
+) {
+  var reloadKey by remember { mutableStateOf(0) }
+  var state by
+    remember(repertoireId) { mutableStateOf<RepertoireViewState>(RepertoireViewState.Loading) }
+  LaunchedEffect(repertoireId, reloadKey) {
+    state = RepertoireViewState.Loading
+    state = loadRepertoire(repertoireId, catalog, client)
+  }
+
+  Box(
+    modifier = Modifier.fillMaxSize().testTag(REPERTOIRE_VIEW_TEST_TAG),
+    contentAlignment = Alignment.Center,
+  ) {
+    when (val current = state) {
+      is RepertoireViewState.Loading -> CircularProgressIndicator()
+      is RepertoireViewState.Error ->
+        RepertoireViewError(error = current.error, onRetry = { reloadKey++ })
+      is RepertoireViewState.Ready ->
+        RepertoireViewReady(
+          explorer = current.explorer,
+          descriptor = current.descriptor,
+          cachedExplorer = cachedExplorer,
+        )
+    }
+  }
+}
+
+/** Wires the explorer view model and renders the read-only [ExplorerContent]. */
+@Composable
+private fun RepertoireViewReady(
+  explorer: RepertoireExplorer,
+  descriptor: RepertoireDescriptor,
+  cachedExplorer: CachedExplorer,
+) {
+  val coroutineScope = rememberCoroutineScope()
+  val explorerViewModel =
+    remember(cachedExplorer, coroutineScope) { ExplorerViewModel(cachedExplorer, coroutineScope) }
+  LaunchedEffect(explorer) { explorerViewModel.setFen(explorer.engine.toFen().value) }
+  remember { explorer.registerCallBack { explorerViewModel.setFen(explorer.engine.toFen().value) } }
+  ExplorerContent(
+    explorer = explorer,
+    explorerViewModel = explorerViewModel,
+    onSave = {},
+    onDelete = {},
+    readOnly = true,
+    initialInverted = descriptor.color == RepertoireColor.BLACK,
+    cornerTag = descriptor.name,
+  )
+}
+
+/** Error body with a retry action, mirroring the catalog error styling of the library page. */
+@Composable
+private fun RepertoireViewError(error: RepertoireViewError, onRetry: () -> Unit) {
+  val palette = LocalKineticPalette.current
+  val typography = LocalKineticTypography.current
+  Column(
+    modifier = Modifier.padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(text = error.resolveMessage(), style = typography.bodySm.copy(color = palette.red))
+    KineticButton(onClick = onRetry) {
+      KineticButtonLabel(stringResource(Res.string.library_retry))
+    }
+  }
+}
+
+/** Resolves the localized message for a [RepertoireViewError]. */
+@Composable
+private fun RepertoireViewError.resolveMessage(): String =
+  when (this) {
+    is RepertoireViewError.Network -> stringResource(Res.string.library_error_network, message)
+    is RepertoireViewError.Http -> stringResource(Res.string.library_error_http, status)
+    is RepertoireViewError.MalformedManifest ->
+      stringResource(Res.string.library_error_malformed, message)
+    is RepertoireViewError.MalformedPgn ->
+      stringResource(Res.string.library_install_error_malformed_pgn, message)
+    is RepertoireViewError.Import ->
+      stringResource(Res.string.library_install_error_import, message)
+    is RepertoireViewError.NotFound -> stringResource(Res.string.repertoire_view_not_found, id)
+  }
+
+/**
+ * Loads the repertoire: resolves its descriptor from the manifest, downloads and parses its PGN,
+ * then builds the read-only explorer. Every failure maps to a typed [RepertoireViewError].
+ */
+private suspend fun loadRepertoire(
+  repertoireId: String,
+  catalog: CachedRepertoireCatalog,
+  client: RepertoireCatalogClient,
+): RepertoireViewState {
+  val descriptor =
+    when (val manifest = catalog.getManifest()) {
+      is CachedManifestResult.Fresh -> manifest.manifest.repertoires.find { it.id == repertoireId }
+      is CachedManifestResult.Stale -> manifest.manifest.repertoires.find { it.id == repertoireId }
+      is CachedManifestResult.NetworkError ->
+        return RepertoireViewState.Error(RepertoireViewError.Network(manifest.message))
+      is CachedManifestResult.HttpError ->
+        return RepertoireViewState.Error(RepertoireViewError.Http(manifest.status))
+      is CachedManifestResult.MalformedManifest ->
+        return RepertoireViewState.Error(RepertoireViewError.MalformedManifest(manifest.message))
+    } ?: return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
+
+  val games =
+    when (val result = client.fetchPgn(descriptor.file)) {
+      is CatalogResult.Ok -> result.value
+      is CatalogResult.NetworkError ->
+        return RepertoireViewState.Error(RepertoireViewError.Network(result.message))
+      is CatalogResult.HttpError ->
+        return RepertoireViewState.Error(RepertoireViewError.Http(result.status))
+      is CatalogResult.MalformedPgn ->
+        return RepertoireViewState.Error(RepertoireViewError.MalformedPgn(result.message))
+      // A PGN fetch never reports MalformedManifest; mapped defensively for exhaustiveness.
+      is CatalogResult.MalformedManifest ->
+        return RepertoireViewState.Error(RepertoireViewError.MalformedPgn(result.message))
+    }
+
+  return try {
+    RepertoireViewState.Ready(RepertoireExplorer.build(games), descriptor)
+  } catch (e: PgnImportException) {
+    RepertoireViewState.Error(RepertoireViewError.Import(e.message ?: "Import failed"))
+  }
+}
+
+/** Loading lifecycle of the repertoire viewer. */
+private sealed interface RepertoireViewState {
+
+  /** The descriptor and PGN are being fetched. */
+  data object Loading : RepertoireViewState
+
+  /** Loading failed; [error] describes how. */
+  data class Error(val error: RepertoireViewError) : RepertoireViewState
+
+  /** The PGN is loaded and [explorer] is ready to navigate [descriptor]. */
+  data class Ready(val explorer: RepertoireExplorer, val descriptor: RepertoireDescriptor) :
+    RepertoireViewState
+}
+
+/** Reason a repertoire could not be opened. */
+private sealed interface RepertoireViewError {
+
+  /** Manifest or PGN download failed before an HTTP status was obtained. */
+  data class Network(val message: String) : RepertoireViewError
+
+  /** A download answered with a non success HTTP [status]. */
+  data class Http(val status: Int) : RepertoireViewError
+
+  /** The manifest is invalid. */
+  data class MalformedManifest(val message: String) : RepertoireViewError
+
+  /** The PGN does not parse or contains no moves. */
+  data class MalformedPgn(val message: String) : RepertoireViewError
+
+  /** The PGN parsed but contains an illegal move and could not be replayed. */
+  data class Import(val message: String) : RepertoireViewError
+
+  /** No repertoire with [id] exists in the manifest. */
+  data class NotFound(val id: String) : RepertoireViewError
+}

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +28,6 @@ import memorchess.composeapp.generated.resources.repertoire_view_not_found
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import proj.memorchess.axl.core.data.explorer.CachedExplorer
-import proj.memorchess.axl.core.data.explorer.ExplorerViewModel
 import proj.memorchess.axl.core.data.repertoire.CachedManifestResult
 import proj.memorchess.axl.core.data.repertoire.CachedRepertoireCatalog
 import proj.memorchess.axl.core.data.repertoire.CatalogResult
@@ -99,11 +97,7 @@ private fun RepertoireViewReady(
   descriptor: RepertoireDescriptor,
   cachedExplorer: CachedExplorer,
 ) {
-  val coroutineScope = rememberCoroutineScope()
-  val explorerViewModel =
-    remember(cachedExplorer, coroutineScope) { ExplorerViewModel(cachedExplorer, coroutineScope) }
-  LaunchedEffect(explorer) { explorerViewModel.setFen(explorer.engine.toFen().value) }
-  remember { explorer.registerCallBack { explorerViewModel.setFen(explorer.engine.toFen().value) } }
+  val explorerViewModel = rememberExplorerViewModel(explorer, cachedExplorer)
   ExplorerContent(
     explorer = explorer,
     explorerViewModel = explorerViewModel,
@@ -158,17 +152,20 @@ private suspend fun loadRepertoire(
   catalog: CachedRepertoireCatalog,
   client: RepertoireCatalogClient,
 ): RepertoireViewState {
-  val descriptor =
-    when (val manifest = catalog.getManifest()) {
-      is CachedManifestResult.Fresh -> manifest.manifest.repertoires.find { it.id == repertoireId }
-      is CachedManifestResult.Stale -> manifest.manifest.repertoires.find { it.id == repertoireId }
+  val manifest =
+    when (val result = catalog.getManifest()) {
+      is CachedManifestResult.Fresh -> result.manifest
+      is CachedManifestResult.Stale -> result.manifest
       is CachedManifestResult.NetworkError ->
-        return RepertoireViewState.Error(RepertoireViewError.Network(manifest.message))
+        return RepertoireViewState.Error(RepertoireViewError.Network(result.message))
       is CachedManifestResult.HttpError ->
-        return RepertoireViewState.Error(RepertoireViewError.Http(manifest.status))
+        return RepertoireViewState.Error(RepertoireViewError.Http(result.status))
       is CachedManifestResult.MalformedManifest ->
-        return RepertoireViewState.Error(RepertoireViewError.MalformedManifest(manifest.message))
-    } ?: return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
+        return RepertoireViewState.Error(RepertoireViewError.MalformedManifest(result.message))
+    }
+  val descriptor =
+    manifest.repertoires.find { it.id == repertoireId }
+      ?: return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
 
   val games =
     when (val result = client.fetchPgn(descriptor.file)) {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireView.kt
@@ -168,10 +168,7 @@ private suspend fun loadRepertoire(
         return RepertoireViewState.Error(RepertoireViewError.Http(manifest.status))
       is CachedManifestResult.MalformedManifest ->
         return RepertoireViewState.Error(RepertoireViewError.MalformedManifest(manifest.message))
-    }
-  if (descriptor == null) {
-    return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
-  }
+    } ?: return RepertoireViewState.Error(RepertoireViewError.NotFound(repertoireId))
 
   val games =
     when (val result = client.fetchPgn(descriptor.file)) {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/navigation/Destination.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/navigation/Destination.kt
@@ -59,6 +59,20 @@ sealed interface Route {
     override fun displayNameRes() = Res.string.nav_library
   }
 
+  /**
+   * Read-only viewer for a single catalog repertoire. Reached from the library; not part of the
+   * bottom navigation bar.
+   *
+   * @property repertoireId Id of the repertoire to display, as listed in the catalog manifest.
+   */
+  @Serializable
+  @SerialName("repertoireView")
+  data class RepertoireViewRoute(@SerialName("id") val repertoireId: String) : Route {
+    override fun getLabel(): String = "RepertoireView"
+
+    override fun displayNameRes() = Res.string.nav_library
+  }
+
   /** Settings route. */
   @Serializable
   @SerialName("settings")

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/navigation/Router.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/navigation/Router.kt
@@ -18,6 +18,7 @@ import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.ui.components.navigation.wipeReveal
 import proj.memorchess.axl.ui.pages.Explore
 import proj.memorchess.axl.ui.pages.RepertoireLibrary
+import proj.memorchess.axl.ui.pages.RepertoireView
 import proj.memorchess.axl.ui.pages.Settings
 import proj.memorchess.axl.ui.pages.Training
 import proj.memorchess.axl.ui.theme.KineticMotion
@@ -37,6 +38,9 @@ internal fun NavBackStackEntry.routeOrdinal(): Int {
   return when {
     route.contains("explore") -> 0
     route.contains("training") -> 1
+    // The viewer shares the library ordinal so the wipe direction stays consistent. Its route
+    // string ("repertoireview") is disjoint from "library", so it needs its own branch.
+    route.contains("repertoireview") -> 2
     route.contains("library") -> 2
     route.contains("settings") -> 3
     else -> 1
@@ -83,6 +87,12 @@ fun Router(navController: NavHostController, modifier: Modifier = Modifier) {
     composable<Route.LibraryRoute> {
       Box(modifier = Modifier.fillMaxSize().then(wipeReveal(revealFromRight))) {
         RepertoireLibrary()
+      }
+    }
+    composable<Route.RepertoireViewRoute> {
+      val repertoireId = it.toRoute<Route.RepertoireViewRoute>().repertoireId
+      Box(modifier = Modifier.fillMaxSize().then(wipeReveal(revealFromRight))) {
+        RepertoireView(repertoireId)
       }
     }
     composable<Route.SettingsRoute> {

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
@@ -71,6 +71,18 @@ class TestInMemoryDatabaseQueryManager {
   }
 
   @Test
+  fun hardDeletingALeafKeepsUnrelatedMovesOfOtherNodes() = runTest {
+    val database = seededLine()
+    database.deletePosition(key2, DeleteMode.HARD)
+    assertNull(database.getPosition(key2))
+    // key0 never referenced key2, so its e4 move (to key1) survives the cascade untouched.
+    assertEquals(setOf("e4"), database.getPosition(key0)!!.previousAndNextMoves.nextMoves.keys)
+    // key1 keeps its incoming e4 but loses its outgoing e5, which pointed at the removed key2.
+    assertEquals(setOf("e4"), database.getPosition(key1)!!.previousAndNextMoves.previousMoves.keys)
+    assertTrue(database.getPosition(key1)!!.previousAndNextMoves.nextMoves.isEmpty())
+  }
+
+  @Test
   fun softDeletingAPositionHidesItButKeepsTheRow() = runTest {
     val database = seededLine()
     database.deletePosition(key1, DeleteMode.SOFT)
@@ -112,6 +124,32 @@ class TestInMemoryDatabaseQueryManager {
     database.deleteMove(key0, "Qh5", DeleteMode.HARD)
     database.deleteMove(keyAfter("d4"), "d5", DeleteMode.HARD)
     assertEquals(setOf("e4"), database.getPosition(key0)!!.previousAndNextMoves.nextMoves.keys)
+  }
+
+  @Test
+  fun deletingAMoveWhoseDestinationIsAbsentUpdatesOnlyTheOrigin() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    // Only the origin exists; its e4 edge points at a key1 node that was never inserted.
+    database.insertNodes(node(key0, previous = listOf(), next = listOf(moveE4)))
+    database.deleteMove(key0, "e4", DeleteMode.HARD)
+    assertTrue(database.getPosition(key0)!!.previousAndNextMoves.nextMoves.isEmpty())
+    assertNull(database.getPosition(key1))
+  }
+
+  @Test
+  fun hardDeletingOneOfSeveralMovesKeepsTheOthers() = runTest {
+    val keyD4 = keyAfter("d4")
+    val moveD4 = DataMove(key0, keyD4, "d4", isGood = true)
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      node(key0, previous = listOf(), next = listOf(moveE4, moveD4)),
+      node(key1, previous = listOf(moveE4), next = listOf()),
+      node(keyD4, previous = listOf(moveD4), next = listOf()),
+    )
+    database.deleteMove(key0, "e4", DeleteMode.HARD)
+    // d4 is left in place; only the matching e4 is removed from the origin.
+    assertEquals(setOf("d4"), database.getPosition(key0)!!.previousAndNextMoves.nextMoves.keys)
+    assertTrue(database.getPosition(key1)!!.previousAndNextMoves.previousMoves.isEmpty())
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
@@ -1,0 +1,149 @@
+package proj.memorchess.axl.core.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+import proj.memorchess.axl.core.engine.GameEngine
+import proj.memorchess.axl.core.graph.DeleteMode
+import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.scheduling.CardStateFactory
+
+/**
+ * Direct branch coverage for [InMemoryDatabaseQueryManager]: insert/query, hard and soft deletes of
+ * both positions and moves, incident-move stripping, erase, and the last-update aggregate.
+ */
+class TestInMemoryDatabaseQueryManager {
+
+  // A three position line start -e4-> key1 -e5-> key2, with the matching incident moves.
+  private val key0 = keyAfter()
+  private val key1 = keyAfter("e4")
+  private val key2 = keyAfter("e4", "e5")
+  private val moveE4 = DataMove(key0, key1, "e4", isGood = true)
+  private val moveE5 = DataMove(key1, key2, "e5", isGood = true)
+
+  private fun keyAfter(vararg moves: String): PositionKey {
+    val engine = GameEngine()
+    moves.forEach { engine.playSanMove(it) }
+    return engine.toPositionKey()
+  }
+
+  private fun node(
+    key: PositionKey,
+    previous: List<DataMove>,
+    next: List<DataMove>,
+    updatedAt: Instant = Instant.fromEpochSeconds(0),
+  ) = DataNode(key, PreviousAndNextMoves(previous, next), CardStateFactory.new(), 0, updatedAt)
+
+  private suspend fun seededLine(): InMemoryDatabaseQueryManager {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      node(key0, previous = listOf(), next = listOf(moveE4)),
+      node(key1, previous = listOf(moveE4), next = listOf(moveE5)),
+      node(key2, previous = listOf(moveE5), next = listOf()),
+    )
+    return database
+  }
+
+  @Test
+  fun insertsAndReadsBack() = runTest {
+    val database = seededLine()
+    assertEquals(3, database.getAllNodes().size)
+    assertEquals(setOf("e5"), database.getPosition(key1)?.previousAndNextMoves?.nextMoves?.keys)
+  }
+
+  @Test
+  fun getPositionReturnsNullForUnknownKey() = runTest {
+    assertNull(seededLine().getPosition(keyAfter("d4")))
+  }
+
+  @Test
+  fun hardDeletingAPositionStripsItsIncidentMoves() = runTest {
+    val database = seededLine()
+    database.deletePosition(key1, DeleteMode.HARD)
+    assertNull(database.getPosition(key1))
+    assertEquals(2, database.getAllNodes().size)
+    // e4 pointed at key1, e5 came from key1: both are gone from the surviving neighbours.
+    assertTrue(database.getPosition(key0)!!.previousAndNextMoves.nextMoves.isEmpty())
+    assertTrue(database.getPosition(key2)!!.previousAndNextMoves.previousMoves.isEmpty())
+  }
+
+  @Test
+  fun softDeletingAPositionHidesItButKeepsTheRow() = runTest {
+    val database = seededLine()
+    database.deletePosition(key1, DeleteMode.SOFT)
+    assertNull(database.getPosition(key1))
+    assertEquals(2, database.getAllNodes().size)
+    val withDeleted = database.getAllNodes(withDeletedOnes = true)
+    assertEquals(3, withDeleted.size)
+    assertTrue(withDeleted.single { it.positionKey == key1 }.isDeleted)
+  }
+
+  @Test
+  fun deletingAMissingPositionIsANoOp() = runTest {
+    val database = seededLine()
+    database.deletePosition(keyAfter("d4"), DeleteMode.HARD)
+    assertEquals(3, database.getAllNodes().size)
+  }
+
+  @Test
+  fun hardDeletingAMoveRemovesItFromBothEnds() = runTest {
+    val database = seededLine()
+    database.deleteMove(key1, "e5", DeleteMode.HARD)
+    assertTrue(database.getPosition(key1)!!.previousAndNextMoves.nextMoves.isEmpty())
+    assertTrue(database.getPosition(key2)!!.previousAndNextMoves.previousMoves.isEmpty())
+  }
+
+  @Test
+  fun softDeletingAMoveFlagsItOnBothEnds() = runTest {
+    val database = seededLine()
+    database.deleteMove(key1, "e5", DeleteMode.SOFT)
+    assertTrue(database.getPosition(key1)!!.previousAndNextMoves.nextMoves.getValue("e5").isDeleted)
+    assertTrue(
+      database.getPosition(key2)!!.previousAndNextMoves.previousMoves.getValue("e5").isDeleted
+    )
+  }
+
+  @Test
+  fun deletingAMissingMoveIsANoOp() = runTest {
+    val database = seededLine()
+    database.deleteMove(key0, "Qh5", DeleteMode.HARD)
+    database.deleteMove(keyAfter("d4"), "d5", DeleteMode.HARD)
+    assertEquals(setOf("e4"), database.getPosition(key0)!!.previousAndNextMoves.nextMoves.keys)
+  }
+
+  @Test
+  fun eraseAllClearsEverything() = runTest {
+    val database = seededLine()
+    database.eraseAll()
+    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+  }
+
+  @Test
+  fun lastUpdateIsNullWhenEmpty() = runTest {
+    assertNull(InMemoryDatabaseQueryManager().getLastUpdate())
+  }
+
+  @Test
+  fun lastUpdateIsTheLatestOfNodesAndMoves() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val moveStamp = Instant.fromEpochSeconds(500)
+    val nodeStamp = Instant.fromEpochSeconds(200)
+    val recentMove = DataMove(key0, key1, "e4", isGood = true, updatedAt = moveStamp)
+    database.insertNodes(
+      node(key0, previous = listOf(), next = listOf(recentMove), updatedAt = nodeStamp)
+    )
+    // The move is newer than its node, so it drives the aggregate.
+    assertEquals(moveStamp, database.getLastUpdate())
+  }
+
+  @Test
+  fun lastUpdateFallsBackToNodeStampWhenItIsLatest() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val nodeStamp = Instant.fromEpochSeconds(900)
+    database.insertNodes(node(key0, previous = listOf(), next = listOf(), updatedAt = nodeStamp))
+    assertEquals(nodeStamp, database.getLastUpdate())
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestRepertoireExplorer.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestRepertoireExplorer.kt
@@ -1,0 +1,138 @@
+package proj.memorchess.axl.core.interaction
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.engine.GameEngine
+import proj.memorchess.axl.core.interactions.RepertoireExplorer
+import proj.memorchess.axl.core.pgn.PgnGame
+import proj.memorchess.axl.core.pgn.PgnParser
+import proj.memorchess.axl.test_util.TestWithKoin
+
+/**
+ * Exercises the read-only repertoire navigator: only PGN moves are playable, off-book moves are
+ * rejected, navigation walks the transient graph, and transpositions are shared.
+ */
+class TestRepertoireExplorer : TestWithKoin() {
+
+  private suspend fun explorerOf(vararg pgns: String): RepertoireExplorer {
+    val games: List<PgnGame> = pgns.flatMap { PgnParser.parse(it) }
+    return RepertoireExplorer.build(games)
+  }
+
+  private fun keyAfter(vararg moves: String): PositionKey {
+    val engine = GameEngine()
+    moves.forEach { engine.playSanMove(it) }
+    return engine.toPositionKey()
+  }
+
+  private suspend fun clickMove(explorer: RepertoireExplorer, from: String, to: String) {
+    explorer.clickOnTile(Pair(from[1] - '1', from[0] - 'a'))
+    explorer.clickOnTile(Pair(to[1] - '1', to[0] - 'a'))
+  }
+
+  @Test
+  fun nextMovesAtRootAreTheBookFirstMoves() = test {
+    val explorer = explorerOf("1. e4 e5 2. Nf3 *")
+    assertEquals(listOf("e4"), explorer.getNextMoves())
+  }
+
+  @Test
+  fun playingABookMoveAdvances() = test {
+    val explorer = explorerOf("1. e4 e5 2. Nf3 *")
+    explorer.playMove("e4")
+    assertEquals(keyAfter("e4"), explorer.engine.toPositionKey())
+    assertEquals(listOf("e5"), explorer.getNextMoves())
+  }
+
+  @Test
+  fun playingAnOffBookMoveIsRejected() = test {
+    val explorer = explorerOf("1. e4 e5 *")
+    // d4 is a legal chess move but is not part of the repertoire.
+    explorer.playMove("d4")
+    assertEquals(PositionKey.START_POSITION, explorer.engine.toPositionKey())
+    assertEquals(listOf("e4"), explorer.getNextMoves())
+  }
+
+  @Test
+  fun clickingAnOffBookMoveIsRejected() = test {
+    val explorer = explorerOf("1. e4 e5 *")
+    // Drag the d-pawn d2-d4: legal, but off-book, so the board must snap back.
+    clickMove(explorer, "d2", "d4")
+    assertEquals(PositionKey.START_POSITION, explorer.engine.toPositionKey())
+  }
+
+  @Test
+  fun clickingABookMoveAdvances() = test {
+    val explorer = explorerOf("1. e4 e5 *")
+    clickMove(explorer, "e2", "e4")
+    assertEquals(keyAfter("e4"), explorer.engine.toPositionKey())
+  }
+
+  @Test
+  fun backAndForwardWalkTheLine() = test {
+    val explorer = explorerOf("1. e4 e5 2. Nf3 *")
+    explorer.playMove("e4")
+    explorer.playMove("e5")
+    assertEquals(keyAfter("e4", "e5"), explorer.engine.toPositionKey())
+    explorer.back()
+    assertEquals(keyAfter("e4"), explorer.engine.toPositionKey())
+    explorer.forward()
+    assertEquals(keyAfter("e4", "e5"), explorer.engine.toPositionKey())
+  }
+
+  @Test
+  fun resetReturnsToTheRoot() = test {
+    val explorer = explorerOf("1. e4 e5 *")
+    explorer.playMove("e4")
+    explorer.reset()
+    assertEquals(PositionKey.START_POSITION, explorer.engine.toPositionKey())
+    assertEquals(listOf("e4"), explorer.getNextMoves())
+  }
+
+  @Test
+  fun branchesOfferEveryBookContinuation() = test {
+    // One position, two book replies.
+    val explorer = explorerOf("1. e4 e5 2. Nf3 (2. Bc4) *")
+    explorer.playMove("e4")
+    explorer.playMove("e5")
+    assertEquals(listOf("Bc4", "Nf3"), explorer.getNextMoves())
+  }
+
+  @Test
+  fun transposedLinesShareTheSamePosition() = test {
+    // Two move orders reaching the same position via different first moves.
+    val explorer = explorerOf("1. d4 d5 2. Nf3 *", "1. Nf3 d5 2. d4 *")
+    assertEquals(listOf("Nf3", "d4"), explorer.getNextMoves())
+
+    explorer.playMove("d4")
+    explorer.playMove("d5")
+    explorer.playMove("Nf3")
+    val viaDFirst = explorer.engine.toPositionKey()
+
+    explorer.reset()
+    explorer.playMove("Nf3")
+    explorer.playMove("d5")
+    explorer.playMove("d4")
+    val viaKnightFirst = explorer.engine.toPositionKey()
+
+    assertEquals(viaDFirst, viaKnightFirst)
+    assertEquals(keyAfter("d4", "d5", "Nf3"), viaDFirst)
+  }
+
+  @Test
+  fun emptyRepertoireHasNoMoves() = test {
+    val explorer = explorerOf("*")
+    assertEquals(PositionKey.START_POSITION, explorer.engine.toPositionKey())
+    assertTrue(explorer.getNextMoves().isEmpty())
+  }
+
+  @Test
+  fun singleMoveRepertoireEndsAfterThatMove() = test {
+    val explorer = explorerOf("1. e4 *")
+    assertEquals(listOf("e4"), explorer.getNextMoves())
+    explorer.playMove("e4")
+    assertTrue(explorer.getNextMoves().isEmpty())
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabaseQueryManager.kt
@@ -1,141 +1,27 @@
 package proj.memorchess.axl.test_util
 
-import kotlin.time.Instant
 import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
-import proj.memorchess.axl.core.data.DatabaseQueryManager
+import proj.memorchess.axl.core.data.InMemoryDatabaseQueryManager
 import proj.memorchess.axl.core.data.PositionKey
-import proj.memorchess.axl.core.date.DateUtil
 import proj.memorchess.axl.core.engine.GameEngine
-import proj.memorchess.axl.core.graph.DeleteMode
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardStateFactory
 
 /**
- * Test in memory database. Mirrors the behaviour of the real platform implementations: hard deletes
- * physically remove rows, soft deletes flip the [DataNode.isDeleted] flag.
+ * In memory database for tests, prefilled with common openings.
+ *
+ * The storage itself is the production [InMemoryDatabaseQueryManager]; this subclass only adds the
+ * test conveniences: a direct [dataNodes] view for assertions and the opening fixtures below. Using
+ * the real implementation keeps the tests honest and exercises it from the whole suite.
  *
  * @constructor Creates an empty test database.
  */
-class TestDatabaseQueryManager private constructor() : DatabaseQueryManager {
-  val dataNodes = mutableMapOf<PositionKey, DataNode>()
+class TestDatabaseQueryManager private constructor() : InMemoryDatabaseQueryManager() {
 
-  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> {
-    return dataNodes.values.filter { withDeletedOnes || !it.isDeleted }.toList()
-  }
-
-  override suspend fun getPosition(positionKey: PositionKey): DataNode? {
-    val node = dataNodes[positionKey]
-    return if (node?.isDeleted == false) node else null
-  }
-
-  override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) {
-    val node = dataNodes[position] ?: return
-    when (mode) {
-      DeleteMode.HARD -> {
-        dataNodes.remove(position)
-        // Hard delete also drops incident edges from other nodes' move maps.
-        for ((key, other) in dataNodes.toMap()) {
-          val nextMoves =
-            other.previousAndNextMoves.nextMoves.values.filter { it.destination != position }
-          val previousMoves =
-            other.previousAndNextMoves.previousMoves.values.filter { it.origin != position }
-          if (
-            nextMoves.size != other.previousAndNextMoves.nextMoves.size ||
-              previousMoves.size != other.previousAndNextMoves.previousMoves.size
-          ) {
-            dataNodes[key] =
-              DataNode(
-                other.positionKey,
-                PreviousAndNextMoves(previousMoves, nextMoves),
-                other.cardState,
-                other.depth,
-                other.updatedAt,
-                other.isDeleted,
-              )
-          }
-        }
-      }
-      DeleteMode.SOFT ->
-        dataNodes[position] =
-          DataNode(
-            node.positionKey,
-            node.previousAndNextMoves,
-            node.cardState,
-            node.depth,
-            DateUtil.now(),
-            true,
-          )
-    }
-  }
-
-  override suspend fun deleteMove(origin: PositionKey, move: String, mode: DeleteMode) {
-    val storedNode = dataNodes[origin] ?: return
-    var destination: PositionKey? = null
-    val newNextMoves =
-      storedNode.previousAndNextMoves.nextMoves.values.mapNotNull {
-        if (it.move != move) it
-        else {
-          destination = it.destination
-          when (mode) {
-            DeleteMode.HARD -> null
-            DeleteMode.SOFT -> it.copy(isDeleted = true, updatedAt = DateUtil.now())
-          }
-        }
-      }
-    dataNodes[origin] =
-      DataNode(
-        origin,
-        PreviousAndNextMoves(storedNode.previousAndNextMoves.previousMoves.values, newNextMoves),
-        storedNode.cardState,
-        storedNode.depth,
-        storedNode.updatedAt,
-      )
-    val dest = destination ?: return
-    val destinationNode = dataNodes[dest] ?: return
-    val newPreviousMoves =
-      destinationNode.previousAndNextMoves.previousMoves.values.mapNotNull {
-        if (it.move != move) it
-        else
-          when (mode) {
-            DeleteMode.HARD -> null
-            DeleteMode.SOFT -> it.copy(isDeleted = true, updatedAt = DateUtil.now())
-          }
-      }
-    dataNodes[dest] =
-      DataNode(
-        destinationNode.positionKey,
-        PreviousAndNextMoves(
-          newPreviousMoves,
-          destinationNode.previousAndNextMoves.nextMoves.values,
-        ),
-        destinationNode.cardState,
-        destinationNode.depth,
-        destinationNode.updatedAt,
-      )
-  }
-
-  override suspend fun eraseAll() {
-    dataNodes.clear()
-  }
-
-  override suspend fun insertNodes(vararg positions: DataNode) {
-    positions.forEach { dataNodes[it.positionKey] = it }
-  }
-
-  override suspend fun getLastUpdate(): Instant? {
-    val node = dataNodes.values.maxOfOrNull { it.updatedAt }
-    val move =
-      dataNodes.values
-        .map { (it.previousAndNextMoves.previousMoves + it.previousAndNextMoves.nextMoves).values }
-        .flatten()
-        .maxOfOrNull { it.updatedAt }
-    return when {
-      node == null -> move
-      move == null -> node
-      else -> maxOf(node, move)
-    }
-  }
+  /** Direct view of the stored nodes (including soft-deleted ones) for assertions and seeding. */
+  val dataNodes: MutableMap<PositionKey, DataNode>
+    get() = nodes
 
   /**
    * Utility methods to create test databases prefilled with common chess openings, as well as to

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
@@ -1,0 +1,124 @@
+package proj.memorchess.axl.ui.repertoire
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import proj.memorchess.axl.core.data.repertoire.CachedRepertoireCatalog
+import proj.memorchess.axl.core.data.repertoire.LibraryCatalogState
+import proj.memorchess.axl.core.data.repertoire.RepertoireCatalogClient
+import proj.memorchess.axl.core.data.repertoire.RepertoireColor
+import proj.memorchess.axl.core.data.repertoire.RepertoireDescriptor
+import proj.memorchess.axl.core.data.repertoire.RepertoireInstallState
+import proj.memorchess.axl.core.engine.ChessPiece
+import proj.memorchess.axl.core.engine.PieceKind
+import proj.memorchess.axl.core.engine.Player
+import proj.memorchess.axl.test_util.TestWithKoin
+import proj.memorchess.axl.ui.assertTileContainsPiece
+import proj.memorchess.axl.ui.assertTileIsEmpty
+import proj.memorchess.axl.ui.pages.RepertoireLibraryContent
+import proj.memorchess.axl.ui.pages.RepertoireView
+import proj.memorchess.axl.ui.playMove
+
+@OptIn(ExperimentalTestApi::class)
+class TestRepertoireView : TestWithKoin() {
+
+  private val whitePawn = ChessPiece(PieceKind.PAWN, Player.WHITE)
+
+  private val descriptor =
+    RepertoireDescriptor(
+      id = "test-rep",
+      name = "Test Repertoire",
+      color = RepertoireColor.WHITE,
+      description = "A tiny repertoire.",
+      moveCount = 3,
+      file = "pgn/test.pgn",
+    )
+
+  /** Catalog + client backed by a [MockEngine] serving a one line manifest and PGN. */
+  private fun mockCatalog(
+    pgn: String = "1. e4 e5 2. Nf3 *"
+  ): Pair<CachedRepertoireCatalog, RepertoireCatalogClient> {
+    val manifest =
+      """{"schemaVersion":1,"repertoires":[{"id":"test-rep","name":"Test Repertoire",""" +
+        """"color":"white","description":"A tiny repertoire.","moveCount":3,""" +
+        """"file":"pgn/test.pgn"}]}"""
+    val engine = MockEngine { request ->
+      val path = request.url.encodedPath
+      when {
+        path.endsWith("manifest.json") -> respond(manifest, HttpStatusCode.OK)
+        path.endsWith("test.pgn") -> respond(pgn, HttpStatusCode.OK)
+        else -> respond("", HttpStatusCode.NotFound)
+      }
+    }
+    val client = RepertoireCatalogClient(HttpClient(engine), baseUrl = "https://example.test")
+    return CachedRepertoireCatalog(client) to client
+  }
+
+  private fun runViewer(pgn: String = "1. e4 e5 2. Nf3 *", block: ComposeUiTest.() -> Unit) =
+    runComposeUiTest {
+      koinSetUp()
+      try {
+        val (catalog, client) = mockCatalog(pgn)
+        setContent { InitializeApp { RepertoireView("test-rep", catalog, client) } }
+        block()
+      } finally {
+        koinTearDown()
+      }
+    }
+
+  @Test
+  fun bookMoveCanBePlayed() = runViewer {
+    assertTileContainsPiece("e2", whitePawn)
+    playMove("e2", "e4")
+    assertTileContainsPiece("e4", whitePawn)
+    assertTileIsEmpty("e2")
+  }
+
+  @Test
+  fun offBookMoveIsRejected() = runViewer {
+    assertTileContainsPiece("e2", whitePawn)
+    // d2-d4 is legal but not in the repertoire whose only first move is e4.
+    playMove("d2", "d4")
+    assertTileContainsPiece("d2", whitePawn)
+    assertTileIsEmpty("d4")
+  }
+
+  @Test
+  fun viewerHasNoSaveOrDeleteControls() = runViewer {
+    assertTileContainsPiece("e2", whitePawn)
+    onNodeWithContentDescription("Save").assertDoesNotExist()
+    onNodeWithContentDescription("Delete").assertDoesNotExist()
+  }
+
+  @Test
+  fun cardViewButtonTriggersOnView() = runComposeUiTest {
+    koinSetUp()
+    try {
+      var viewed: RepertoireDescriptor? = null
+      setContent {
+        InitializeApp {
+          RepertoireLibraryContent(
+            catalogState = LibraryCatalogState.Loaded(listOf(descriptor), isStale = false),
+            installStates = emptyMap<String, RepertoireInstallState>(),
+            onInstall = {},
+            onRetry = {},
+            onView = { viewed = it },
+          )
+        }
+      }
+      onNodeWithTag("library_repertoire_card:test-rep:view").performClick()
+      assertEquals(descriptor, viewed)
+    } finally {
+      koinTearDown()
+    }
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
@@ -25,6 +25,7 @@ import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.test_util.TestWithKoin
 import proj.memorchess.axl.ui.assertTileContainsPiece
 import proj.memorchess.axl.ui.assertTileIsEmpty
+import proj.memorchess.axl.ui.pages.RepertoireLibraryActions
 import proj.memorchess.axl.ui.pages.RepertoireLibraryContent
 import proj.memorchess.axl.ui.pages.RepertoireView
 import proj.memorchess.axl.ui.playMove
@@ -111,10 +112,13 @@ class TestRepertoireView : TestWithKoin() {
             catalogState = LibraryCatalogState.Loaded(listOf(descriptor), isStale = false),
             installStates = emptyMap<String, RepertoireInstallState>(),
             previewStates = emptyMap<String, RepertoirePreviewState>(),
-            onInstall = {},
-            onPreviewRequest = {},
-            onRetry = {},
-            onView = { viewed = it },
+            actions =
+              RepertoireLibraryActions(
+                onInstall = {},
+                onPreviewRequest = {},
+                onRetry = {},
+                onView = { viewed = it },
+              ),
           )
         }
       }


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Summary

Adds a board viewer that lets the user **see what is inside a repertoire** — navigate all its lines (e.g. every London System move) on a chessboard, forward/back, branch by branch.

### Why a separate graph
Once a repertoire is installed, its moves merge indistinguishably into the global opening tree (as `isGood=true` edges) with no per-repertoire tag. So the faithful source of a repertoire's contents is its **PGN file**. The viewer re-fetches the PGN every time, replays it into a *throwaway* in-memory graph, and navigates that — leaving the user's real data untouched and working even for repertoires that are not installed (it doubles as a pre-install preview).

## Changes

- **`InMemoryDatabaseQueryManager`** — a no-persistence `DatabaseQueryManager` backing a disposable `TreeStore`. Never touches Room/IndexedDB.
- **`RepertoireExplorer`** — a read-only `LinesExplorer` over the PGN-built tree. Only moves present in the PGN can be played; an off-book (but legal) move snaps the board back and toasts. `build(games)` reuses the existing `PgnImporter`.
- **`RepertoireView`** page — resolves the descriptor from the catalog, downloads the PGN, and renders the Explore layout read-only, oriented to the repertoire's color. Loading / typed-error+retry / ready states.
- **`ExplorerContent`** — gains `readOnly`, `initialInverted`, `cornerTag`. Read-only hides Save/Delete and node-state indicators and shows the repertoire name as the corner tag. `ExploreCtrlBar` gains `showSaveDelete`.
- **Navigation** — new `RepertoireViewRoute(repertoireId)`, registered in `Router` with library-ordinal wipe direction; a "browse" (eye) button on every library card navigates to it via `LocalNavigator`.
- Strings added (EN + FR).

## Tests

- `TestRepertoireExplorer` — 11 cases: book/off-book moves (via `playMove` and board clicks), back/forward/reset, branching continuations, transposition (shared position via different move orders), and empty / single-move edge cases.
- `TestRepertoireView` — book move plays, off-book rejected on the board, no Save/Delete controls render, and the card's view button fires `onView`.

Full desktop suite + `ktfmtCheck` green; JVM, wasmJs and common metadata all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)