### PR TITLE
feat(repertoire): import one-sided repertoires from the player's perspective

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -187,6 +187,7 @@
   <string name="library_retry">RÉESSAYER</string>
   <string name="library_installed_badge">INSTALLÉ</string>
   <string name="library_install">Installer</string>
+  <string name="library_reinstall">Réinstaller</string>
   <string name="library_color_white">BLANCS</string>
   <string name="library_color_black">NOIRS</string>
   <string name="library_fetching">Téléchargement…</string>
@@ -196,6 +197,9 @@
   <string name="library_install_error_http">Échec du téléchargement avec l'erreur HTTP %1$d.</string>
   <string name="library_install_error_malformed_pgn">Ce fichier de répertoire n'a pas pu être lu : %1$s</string>
   <string name="library_install_error_import">Échec de l'import : %1$s</string>
+  <string name="library_preview_checking">Vérification de votre répertoire…</string>
+  <string name="library_preview_in_common">%1$d coups sur %2$d sont déjà dans votre répertoire.</string>
+  <string name="library_preview_in_common_error">Impossible de vérifier vos coups existants.</string>
   <string name="library_preview_question">Ajouter ce répertoire à vos ouvertures ? Les coups existants et leur historique d'entraînement sont conservés.</string>
   <plurals name="library_move_count">
     <item quantity="one">%1$d coup</item>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -187,6 +187,7 @@
   <string name="library_retry">RETRY</string>
   <string name="library_installed_badge">INSTALLED</string>
   <string name="library_install">Install</string>
+  <string name="library_reinstall">Reinstall</string>
   <string name="library_color_white">WHITE</string>
   <string name="library_color_black">BLACK</string>
   <string name="library_fetching">Downloading…</string>
@@ -196,6 +197,9 @@
   <string name="library_install_error_http">Download failed with HTTP error %1$d.</string>
   <string name="library_install_error_malformed_pgn">This repertoire file could not be read: %1$s</string>
   <string name="library_install_error_import">Import failed: %1$s</string>
+  <string name="library_preview_checking">Checking your repertoire…</string>
+  <string name="library_preview_in_common">%1$d of %2$d moves already in your repertoire.</string>
+  <string name="library_preview_in_common_error">Could not check your existing moves.</string>
   <string name="library_preview_question">Add this repertoire to your openings? Existing moves and their training history are kept.</string>
   <plurals name="library_move_count">
     <item quantity="one">%1$d move</item>

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
@@ -211,26 +211,18 @@ class RepertoireLibraryViewModel(
   private suspend fun fetchGames(
     descriptor: RepertoireDescriptor,
     onError: (InstallError) -> Unit,
-  ): List<PgnGame>? =
-    when (val result = fetchPgn(descriptor.file)) {
-      is CatalogResult.Ok -> result.value
-      is CatalogResult.NetworkError -> {
-        onError(InstallError.Network(result.message))
-        null
+  ): List<PgnGame>? {
+    val error =
+      when (val result = fetchPgn(descriptor.file)) {
+        is CatalogResult.Ok -> return result.value
+        is CatalogResult.NetworkError -> InstallError.Network(result.message)
+        is CatalogResult.HttpError -> InstallError.Http(result.status)
+        is CatalogResult.MalformedPgn -> InstallError.MalformedPgn(result.message)
+        is CatalogResult.MalformedManifest -> InstallError.MalformedPgn(result.message)
       }
-      is CatalogResult.HttpError -> {
-        onError(InstallError.Http(result.status))
-        null
-      }
-      is CatalogResult.MalformedPgn -> {
-        onError(InstallError.MalformedPgn(result.message))
-        null
-      }
-      is CatalogResult.MalformedManifest -> {
-        onError(InstallError.MalformedPgn(result.message))
-        null
-      }
-    }
+    onError(error)
+    return null
+  }
 
   private fun fail(id: String, error: InstallError) {
     setInstallState(id, RepertoireInstallState.Failed(error))

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
@@ -165,14 +165,7 @@ class RepertoireLibraryViewModel(
   }
 
   private suspend fun runInstall(descriptor: RepertoireDescriptor) {
-    val games =
-      when (val result = fetchPgn(descriptor.file)) {
-        is CatalogResult.Ok -> result.value
-        else -> {
-          fail(descriptor.id, result.toInstallError())
-          return
-        }
-      }
+    val games = fetchGames(descriptor) { fail(descriptor.id, it) } ?: return
     setInstallState(descriptor.id, RepertoireInstallState.Importing)
     val summary =
       try {
@@ -191,13 +184,8 @@ class RepertoireLibraryViewModel(
 
   private suspend fun runPreview(descriptor: RepertoireDescriptor) {
     val games =
-      when (val result = fetchPgn(descriptor.file)) {
-        is CatalogResult.Ok -> result.value
-        else -> {
-          setPreviewState(descriptor.id, RepertoirePreviewState.Failed(result.toInstallError()))
-          return
-        }
-      }
+      fetchGames(descriptor) { setPreviewState(descriptor.id, RepertoirePreviewState.Failed(it)) }
+        ?: return
     val preview =
       try {
         previewGames(descriptor.color, games)
@@ -214,6 +202,36 @@ class RepertoireLibraryViewModel(
     setPreviewState(descriptor.id, RepertoirePreviewState.Ready(preview))
   }
 
+  /**
+   * Downloads and parses the PGN of [descriptor], shared by install and preview. On a non success
+   * fetch it reports the matching [InstallError] through [onError] and returns `null`; otherwise it
+   * returns the parsed games. A PGN fetch never reports [CatalogResult.MalformedManifest], but it
+   * is mapped defensively for exhaustiveness.
+   */
+  private suspend fun fetchGames(
+    descriptor: RepertoireDescriptor,
+    onError: (InstallError) -> Unit,
+  ): List<PgnGame>? =
+    when (val result = fetchPgn(descriptor.file)) {
+      is CatalogResult.Ok -> result.value
+      is CatalogResult.NetworkError -> {
+        onError(InstallError.Network(result.message))
+        null
+      }
+      is CatalogResult.HttpError -> {
+        onError(InstallError.Http(result.status))
+        null
+      }
+      is CatalogResult.MalformedPgn -> {
+        onError(InstallError.MalformedPgn(result.message))
+        null
+      }
+      is CatalogResult.MalformedManifest -> {
+        onError(InstallError.MalformedPgn(result.message))
+        null
+      }
+    }
+
   private fun fail(id: String, error: InstallError) {
     setInstallState(id, RepertoireInstallState.Failed(error))
   }
@@ -226,20 +244,6 @@ class RepertoireLibraryViewModel(
     internalPreviewStates.value = internalPreviewStates.value + (id to state)
   }
 }
-
-/**
- * Maps a non success catalog fetch to the matching [InstallError]. A PGN fetch never reports
- * [CatalogResult.MalformedManifest], but it is mapped defensively for exhaustiveness, and
- * [CatalogResult.Ok] is not an error.
- */
-private fun CatalogResult<*>.toInstallError(): InstallError =
-  when (this) {
-    is CatalogResult.NetworkError -> InstallError.Network(message)
-    is CatalogResult.HttpError -> InstallError.Http(status)
-    is CatalogResult.MalformedPgn -> InstallError.MalformedPgn(message)
-    is CatalogResult.MalformedManifest -> InstallError.MalformedPgn(message)
-    is CatalogResult.Ok -> error("Ok is not an install error")
-  }
 
 /** State of the catalog list. Consumed by Compose. */
 sealed class LibraryCatalogState {

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/repertoire/RepertoireLibraryViewModel.kt
@@ -8,36 +8,46 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import proj.memorchess.axl.core.pgn.PgnGame
+import proj.memorchess.axl.core.pgn.PgnImportPreview
 import proj.memorchess.axl.core.pgn.PgnImportSummary
 
 /**
  * Drives the repertoire library page.
  *
- * Exposes two flows that the UI renders: [catalogState] for the catalog list (loading, loaded with
- * staleness flag, or one error per failure mode) and [installStates] for the per repertoire install
- * lifecycle. All mutations happen here so the composables stay free of business logic.
+ * Exposes three flows that the UI renders: [catalogState] for the catalog list (loading, loaded
+ * with staleness flag, or one error per failure mode), [installStates] for the per repertoire
+ * install lifecycle, and [previewStates] for the on demand overlap shown before an install. All
+ * mutations happen here so the composables stay free of business logic.
  *
  * The catalog and install collaborators are injected as suspending functions rather than concrete
  * classes so tests can substitute trivial fakes. Production wiring binds them to
- * [CachedRepertoireCatalog.getManifest], [RepertoireCatalogClient.fetchPgn] and
- * [proj.memorchess.axl.core.pgn.PgnImporter.import].
+ * [CachedRepertoireCatalog.getManifest], [RepertoireCatalogClient.fetchPgn],
+ * [proj.memorchess.axl.core.pgn.PgnImporter.import] and
+ * [proj.memorchess.axl.core.pgn.PgnImporter.preview].
  *
- * Reentrancy: [refresh] is ignored while a load is in flight, and [install] is ignored for a
- * repertoire whose install is in flight or already completed. The guards flip state synchronously
- * before any coroutine is launched, so a double tap on the same frame is still coalesced.
+ * Reentrancy: [refresh] is ignored while a load is in flight, [install] is ignored only while a
+ * fetch or import for the same repertoire is in flight (an installed repertoire may be
+ * reinstalled), and [requestPreview] is ignored while a preview for the same repertoire is loading.
+ * The guards flip state synchronously before any coroutine is launched, so a double tap on the same
+ * frame is still coalesced.
  *
  * @param loadManifest Returns the catalog manifest, normally through the persisted cache.
  * @param fetchPgn Downloads and parses the PGN file at the given catalog relative path.
- * @param importGames Merges parsed games into the opening graph and reports the summary. Any
- *   exception it throws is surfaced as [InstallError.ImportFailed] and the repertoire is not marked
- *   installed.
+ * @param importGames Merges parsed games into the opening graph from the repertoire's
+ *   [RepertoireColor] perspective and reports the summary. Any exception it throws is surfaced as
+ *   [InstallError.ImportFailed] and the repertoire is not marked installed.
+ * @param previewGames Computes, without writing anything, how much of the repertoire the user
+ *   already has from the repertoire's [RepertoireColor] perspective.
  * @param installedStore Records which repertoires are installed on this device.
  * @param scope Scope tied to the screen's lifecycle (use `rememberCoroutineScope` in Compose).
  */
 class RepertoireLibraryViewModel(
   private val loadManifest: suspend () -> CachedManifestResult,
   private val fetchPgn: suspend (file: String) -> CatalogResult<List<PgnGame>>,
-  private val importGames: suspend (games: List<PgnGame>) -> PgnImportSummary,
+  private val importGames:
+    suspend (color: RepertoireColor, games: List<PgnGame>) -> PgnImportSummary,
+  private val previewGames:
+    suspend (color: RepertoireColor, games: List<PgnGame>) -> PgnImportPreview,
   private val installedStore: InstalledRepertoireStore,
   private val scope: CoroutineScope,
 ) {
@@ -46,6 +56,8 @@ class RepertoireLibraryViewModel(
     MutableStateFlow<LibraryCatalogState>(LibraryCatalogState.Loading)
   private val internalInstallStates =
     MutableStateFlow<Map<String, RepertoireInstallState>>(emptyMap())
+  private val internalPreviewStates =
+    MutableStateFlow<Map<String, RepertoirePreviewState>>(emptyMap())
   private var loadInFlight = false
 
   /** Current state of the catalog list. */
@@ -57,6 +69,13 @@ class RepertoireLibraryViewModel(
    */
   val installStates: StateFlow<Map<String, RepertoireInstallState>> =
     internalInstallStates.asStateFlow()
+
+  /**
+   * Overlap preview of every repertoire for which one was requested, keyed by
+   * [RepertoireDescriptor.id]. A missing key means no preview has been requested yet.
+   */
+  val previewStates: StateFlow<Map<String, RepertoirePreviewState>> =
+    internalPreviewStates.asStateFlow()
 
   init {
     refresh()
@@ -80,20 +99,36 @@ class RepertoireLibraryViewModel(
 
   /**
    * Starts installing [descriptor]: fetches its PGN file, imports it into the opening graph, and
-   * marks it installed on success only. Ignored when an install for the same repertoire is in
-   * flight or has already completed; a previously failed install may be retried.
+   * marks it installed on success only. Ignored only while a fetch or import for the same
+   * repertoire is already in flight. An already installed repertoire may be reinstalled, which
+   * restores any moves the user has since removed (the import skips the moves still present), and a
+   * previously failed install may be retried.
    */
   fun install(descriptor: RepertoireDescriptor) {
     when (internalInstallStates.value[descriptor.id]) {
       is RepertoireInstallState.Fetching,
-      is RepertoireInstallState.Importing,
-      is RepertoireInstallState.Installed -> return
+      is RepertoireInstallState.Importing -> return
+      is RepertoireInstallState.Installed,
       is RepertoireInstallState.Failed,
       is RepertoireInstallState.NotInstalled,
       null -> Unit
     }
     setInstallState(descriptor.id, RepertoireInstallState.Fetching)
     scope.launch { runInstall(descriptor) }
+  }
+
+  /**
+   * Computes how much of [descriptor] the user already has and publishes it on [previewStates], so
+   * the install confirmation can show the overlap. Ignored while a preview for the same repertoire
+   * is already loading; otherwise it always recomputes, because the graph may have changed since
+   * the last preview.
+   */
+  fun requestPreview(descriptor: RepertoireDescriptor) {
+    if (internalPreviewStates.value[descriptor.id] is RepertoirePreviewState.Loading) {
+      return
+    }
+    setPreviewState(descriptor.id, RepertoirePreviewState.Loading)
+    scope.launch { runPreview(descriptor) }
   }
 
   private suspend fun runLoad() {
@@ -133,28 +168,15 @@ class RepertoireLibraryViewModel(
     val games =
       when (val result = fetchPgn(descriptor.file)) {
         is CatalogResult.Ok -> result.value
-        is CatalogResult.NetworkError -> {
-          fail(descriptor.id, InstallError.Network(result.message))
-          return
-        }
-        is CatalogResult.HttpError -> {
-          fail(descriptor.id, InstallError.Http(result.status))
-          return
-        }
-        // A PGN fetch never reports MalformedManifest; mapped defensively for exhaustiveness.
-        is CatalogResult.MalformedPgn,
-        is CatalogResult.MalformedManifest -> {
-          val message =
-            if (result is CatalogResult.MalformedPgn) result.message
-            else (result as CatalogResult.MalformedManifest).message
-          fail(descriptor.id, InstallError.MalformedPgn(message))
+        else -> {
+          fail(descriptor.id, result.toInstallError())
           return
         }
       }
     setInstallState(descriptor.id, RepertoireInstallState.Importing)
     val summary =
       try {
-        val importSummary = importGames(games)
+        val importSummary = importGames(descriptor.color, games)
         installedStore.markInstalled(descriptor.id)
         importSummary
       } catch (e: CancellationException) {
@@ -167,6 +189,31 @@ class RepertoireLibraryViewModel(
     setInstallState(descriptor.id, RepertoireInstallState.Installed(summary))
   }
 
+  private suspend fun runPreview(descriptor: RepertoireDescriptor) {
+    val games =
+      when (val result = fetchPgn(descriptor.file)) {
+        is CatalogResult.Ok -> result.value
+        else -> {
+          setPreviewState(descriptor.id, RepertoirePreviewState.Failed(result.toInstallError()))
+          return
+        }
+      }
+    val preview =
+      try {
+        previewGames(descriptor.color, games)
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        LOGGER.w(e) { "Preview of repertoire ${descriptor.id} failed" }
+        setPreviewState(
+          descriptor.id,
+          RepertoirePreviewState.Failed(InstallError.ImportFailed(e.message ?: "Preview failed")),
+        )
+        return
+      }
+    setPreviewState(descriptor.id, RepertoirePreviewState.Ready(preview))
+  }
+
   private fun fail(id: String, error: InstallError) {
     setInstallState(id, RepertoireInstallState.Failed(error))
   }
@@ -174,7 +221,25 @@ class RepertoireLibraryViewModel(
   private fun setInstallState(id: String, state: RepertoireInstallState) {
     internalInstallStates.value = internalInstallStates.value + (id to state)
   }
+
+  private fun setPreviewState(id: String, state: RepertoirePreviewState) {
+    internalPreviewStates.value = internalPreviewStates.value + (id to state)
+  }
 }
+
+/**
+ * Maps a non success catalog fetch to the matching [InstallError]. A PGN fetch never reports
+ * [CatalogResult.MalformedManifest], but it is mapped defensively for exhaustiveness, and
+ * [CatalogResult.Ok] is not an error.
+ */
+private fun CatalogResult<*>.toInstallError(): InstallError =
+  when (this) {
+    is CatalogResult.NetworkError -> InstallError.Network(message)
+    is CatalogResult.HttpError -> InstallError.Http(status)
+    is CatalogResult.MalformedPgn -> InstallError.MalformedPgn(message)
+    is CatalogResult.MalformedManifest -> InstallError.MalformedPgn(message)
+    is CatalogResult.Ok -> error("Ok is not an install error")
+  }
 
 /** State of the catalog list. Consumed by Compose. */
 sealed class LibraryCatalogState {
@@ -219,6 +284,19 @@ sealed class RepertoireInstallState {
 
   /** The last install attempt failed with [error]. The install may be retried. */
   data class Failed(val error: InstallError) : RepertoireInstallState()
+}
+
+/** On demand overlap of one catalog repertoire against the user's graph. Consumed by Compose. */
+sealed class RepertoirePreviewState {
+
+  /** The overlap is being computed (PGN download plus comparison). */
+  data object Loading : RepertoirePreviewState()
+
+  /** The overlap was computed: [preview] holds the repertoire size and the moves in common. */
+  data class Ready(val preview: PgnImportPreview) : RepertoirePreviewState()
+
+  /** The overlap could not be computed because of [error]. The install button stays usable. */
+  data class Failed(val error: InstallError) : RepertoirePreviewState()
 }
 
 /** Reason an install attempt failed. */

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/pgn/PgnImportPreview.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/pgn/PgnImportPreview.kt
@@ -1,0 +1,11 @@
+package proj.memorchess.axl.core.pgn
+
+/**
+ * Dry run overlap of a repertoire against the user's current graph, computed without writing
+ * anything. Lets the UI tell the user how much of a repertoire they already know before installing.
+ *
+ * @property totalMoves Number of distinct moves the repertoire would import.
+ * @property movesInCommon How many of those moves are already part of the user's graph with the
+ *   same classification, and would therefore be left untouched by an install.
+ */
+data class PgnImportPreview(val totalMoves: Int, val movesInCommon: Int)

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/pgn/PgnImporter.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/pgn/PgnImporter.kt
@@ -3,7 +3,9 @@ package proj.memorchess.axl.core.pgn
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.engine.GameEngine
 import proj.memorchess.axl.core.engine.IllegalMoveException
+import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.core.graph.MoveInsertion
+import proj.memorchess.axl.core.graph.OpeningTree
 import proj.memorchess.axl.core.graph.TreeStore
 
 /**
@@ -14,10 +16,17 @@ import proj.memorchess.axl.core.graph.TreeStore
  * import with a [PgnImportException] before anything is written, so a failed import leaves the
  * graph exactly as it was.
  *
- * Valid moves are inserted through [TreeStore] as repertoire moves (`isGood == true`) in a single
- * batch. Moves the user already trains are skipped, which keeps the existing card state of every
- * position intact. As a consequence, importing the same repertoire twice is a no op whose summary
- * reports every move as already present.
+ * Each move is classified relative to the import's `perspective` (the side whose repertoire this
+ * is): a move played by that side is a repertoire move (`isGood == true`), the opponent's replies
+ * are stored as `isGood == false` so they thread the graph together without ever being drilled.
+ * This mirrors the alternating good/bad classification the manual `LinesExplorer` save flow
+ * produces, so installing a one sided opening (e.g. the black Scandinavian) only asks the user to
+ * recall their own moves. A `null` perspective marks every move good, which suits two sided content
+ * such as a Lichess study.
+ *
+ * Moves the user already trains with the same classification are skipped, which keeps the existing
+ * card state of every position intact. As a consequence, importing the same repertoire twice is a
+ * no op whose summary reports every move as already present.
  *
  * The caller is responsible for loading [treeStore] before importing so that the merge sees the
  * persisted graph.
@@ -30,38 +39,61 @@ class PgnImporter(private val treeStore: TreeStore) {
    * Imports [games] into the opening graph.
    *
    * @param games Parsed games, typically obtained from [PgnParser.parse].
+   * @param perspective Side whose repertoire is being imported: only its moves are marked `isGood`,
+   *   the opponent's replies are stored as not good. `null` marks every move good, for two sided
+   *   content such as a Lichess study.
    * @return How many moves were added and how many were already present.
    * @throws PgnImportException if any move of any variation is illegal. Nothing is written in that
    *   case.
    */
-  suspend fun import(games: List<PgnGame>): PgnImportSummary {
-    val plannedMoves = planMoves(games)
+  suspend fun import(games: List<PgnGame>, perspective: Player? = null): PgnImportSummary {
+    val plannedMoves = planMoves(games, perspective)
     val tree = treeStore.current()
-    val movesToInsert = mutableListOf<MoveInsertion>()
-    var alreadyPresent = 0
-    for (plannedMove in plannedMoves) {
-      val existingEdge = tree[plannedMove.from]?.outgoing?.get(plannedMove.move)
-      if (existingEdge != null && existingEdge.isGood == true) {
-        alreadyPresent++
-      } else {
-        movesToInsert += plannedMove
-      }
-    }
+    val (alreadyPresent, movesToInsert) = plannedMoves.partition { isAlreadyPresent(tree, it) }
     treeStore.addMoves(movesToInsert)
-    return PgnImportSummary(movesAdded = movesToInsert.size, movesAlreadyPresent = alreadyPresent)
+    return PgnImportSummary(
+      movesAdded = movesToInsert.size,
+      movesAlreadyPresent = alreadyPresent.size,
+    )
+  }
+
+  /**
+   * Computes how much of [games] the user already has, without writing anything. Reads the graph
+   * currently held by [treeStore], so the caller must load it first, exactly as for [import].
+   *
+   * @param games Parsed games, typically obtained from [PgnParser.parse].
+   * @param perspective Side whose repertoire this is, classified the same way as in [import] so the
+   *   overlap matches what an install would skip. See [import] for the meaning of `null`.
+   * @return The repertoire size and how many of its moves are already present.
+   * @throws PgnImportException if any move of any variation is illegal.
+   */
+  fun preview(games: List<PgnGame>, perspective: Player? = null): PgnImportPreview {
+    val plannedMoves = planMoves(games, perspective)
+    val tree = treeStore.current()
+    val movesInCommon = plannedMoves.count { isAlreadyPresent(tree, it) }
+    return PgnImportPreview(totalMoves = plannedMoves.size, movesInCommon = movesInCommon)
+  }
+
+  /**
+   * Whether [move] is already in [tree] with the same classification, in which case an import would
+   * leave it untouched.
+   */
+  private fun isAlreadyPresent(tree: OpeningTree, move: MoveInsertion): Boolean {
+    val existingEdge = tree[move.from]?.outgoing?.get(move.move)
+    return existingEdge != null && existingEdge.isGood == move.isGood
   }
 
   /**
    * Replays every variation of every game and returns the distinct moves to merge, in discovery
    * order. Throws [PgnImportException] on the first illegal move, before any write happens.
    */
-  private fun planMoves(games: List<PgnGame>): List<MoveInsertion> {
+  private fun planMoves(games: List<PgnGame>, perspective: Player?): List<MoveInsertion> {
     val plannedMoves = mutableListOf<MoveInsertion>()
     val seenMoves = mutableSetOf<Pair<PositionKey, String>>()
     val rootKey = GameEngine().toPositionKey()
     for ((gameIndex, game) in games.withIndex()) {
       for (firstMove in game.moves) {
-        walk(rootKey, 0, firstMove, gameIndex, plannedMoves, seenMoves)
+        walk(rootKey, 0, firstMove, gameIndex, perspective, plannedMoves, seenMoves)
       }
     }
     return plannedMoves
@@ -69,17 +101,20 @@ class PgnImporter(private val treeStore: TreeStore) {
 
   /**
    * Validates [moveNode] from the position [fromKey] at [depth] plies from the start, records the
-   * resulting move, then recurses into every continuation.
+   * resulting move classified for [perspective], then recurses into every continuation.
    */
   private fun walk(
     fromKey: PositionKey,
     depth: Int,
     moveNode: PgnMoveNode,
     gameIndex: Int,
+    perspective: Player?,
     plannedMoves: MutableList<MoveInsertion>,
     seenMoves: MutableSet<Pair<PositionKey, String>>,
   ) {
     val engine = GameEngine(fromKey)
+    // Whose move this is, captured before playing it flips the side to move.
+    val mover = engine.playerTurn
     try {
       engine.playSanMove(moveNode.san)
     } catch (e: IllegalMoveException) {
@@ -95,12 +130,12 @@ class PgnImporter(private val treeStore: TreeStore) {
           from = fromKey,
           move = moveNode.san,
           to = toKey,
-          isGood = true,
+          isGood = perspective == null || mover == perspective,
           fromDepth = depth,
         )
     }
     for (child in moveNode.children) {
-      walk(toKey, depth + 1, child, gameIndex, plannedMoves, seenMoves)
+      walk(toKey, depth + 1, child, gameIndex, perspective, plannedMoves, seenMoves)
     }
   }
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/pages/RepertoireLibrary.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -40,7 +41,11 @@ import memorchess.composeapp.generated.resources.library_install_error_network
 import memorchess.composeapp.generated.resources.library_install_summary
 import memorchess.composeapp.generated.resources.library_installed_badge
 import memorchess.composeapp.generated.resources.library_move_count
+import memorchess.composeapp.generated.resources.library_preview_checking
+import memorchess.composeapp.generated.resources.library_preview_in_common
+import memorchess.composeapp.generated.resources.library_preview_in_common_error
 import memorchess.composeapp.generated.resources.library_preview_question
+import memorchess.composeapp.generated.resources.library_reinstall
 import memorchess.composeapp.generated.resources.library_retry
 import memorchess.composeapp.generated.resources.library_stale_hint
 import memorchess.composeapp.generated.resources.library_subtitle
@@ -57,6 +62,8 @@ import proj.memorchess.axl.core.data.repertoire.RepertoireColor
 import proj.memorchess.axl.core.data.repertoire.RepertoireDescriptor
 import proj.memorchess.axl.core.data.repertoire.RepertoireInstallState
 import proj.memorchess.axl.core.data.repertoire.RepertoireLibraryViewModel
+import proj.memorchess.axl.core.data.repertoire.RepertoirePreviewState
+import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.core.pgn.PgnImporter
 import proj.memorchess.axl.ui.components.buttons.KineticButton
@@ -89,10 +96,15 @@ fun RepertoireLibrary(
       RepertoireLibraryViewModel(
         loadManifest = catalog::getManifest,
         fetchPgn = client::fetchPgn,
-        importGames = { games ->
+        importGames = { color, games ->
           // The importer merges into the loaded tree, so refresh it from disk first.
           treeStore.load()
-          PgnImporter(treeStore).import(games)
+          PgnImporter(treeStore).import(games, color.toPlayer())
+        },
+        previewGames = { color, games ->
+          // The overlap is read against the loaded tree, so refresh it from disk first.
+          treeStore.load()
+          PgnImporter(treeStore).preview(games, color.toPlayer())
         },
         installedStore = installedStore,
         scope = coroutineScope,
@@ -100,14 +112,24 @@ fun RepertoireLibrary(
     }
   val catalogState by viewModel.catalogState.collectAsState()
   val installStates by viewModel.installStates.collectAsState()
+  val previewStates by viewModel.previewStates.collectAsState()
   RepertoireLibraryContent(
     catalogState = catalogState,
     installStates = installStates,
+    previewStates = previewStates,
     onInstall = viewModel::install,
+    onPreviewRequest = viewModel::requestPreview,
     onRetry = viewModel::refresh,
     modifier = Modifier.fillMaxSize().testTag(Route.LibraryRoute.getLabel()),
   )
 }
+
+/** Maps the catalog's [RepertoireColor] to the engine [Player] the importer classifies against. */
+private fun RepertoireColor.toPlayer(): Player =
+  when (this) {
+    RepertoireColor.WHITE -> Player.WHITE
+    RepertoireColor.BLACK -> Player.BLACK
+  }
 
 /**
  * Stateless rendering of the library page. Split out from [RepertoireLibrary] so tests can drive
@@ -117,7 +139,9 @@ fun RepertoireLibrary(
 internal fun RepertoireLibraryContent(
   catalogState: LibraryCatalogState,
   installStates: Map<String, RepertoireInstallState>,
+  previewStates: Map<String, RepertoirePreviewState>,
   onInstall: (RepertoireDescriptor) -> Unit,
+  onPreviewRequest: (RepertoireDescriptor) -> Unit,
   onRetry: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -125,6 +149,9 @@ internal fun RepertoireLibraryContent(
   val typography = LocalKineticTypography.current
   val previewDialog = remember { ConfirmationDialog(okText = Res.string.library_install) }
   previewDialog.DrawDialog()
+  // The dialog keeps the content lambda from the moment it was shown, so read the latest preview
+  // through this holder to reflect the Loading -> Ready transition while the dialog stays open.
+  val latestPreviewStates = rememberUpdatedState(previewStates)
   Column(modifier = modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
     Text(
       text = stringResource(Res.string.library_title),
@@ -162,8 +189,9 @@ internal fun RepertoireLibraryContent(
           state = catalogState,
           installStates = installStates,
           onInstallRequest = { descriptor ->
+            onPreviewRequest(descriptor)
             previewDialog.show(confirm = { onInstall(descriptor) }) {
-              PreviewDialogContent(descriptor)
+              PreviewDialogContent(descriptor, latestPreviewStates.value[descriptor.id])
             }
           },
         )
@@ -330,20 +358,25 @@ private fun InstallStatusRow(installState: RepertoireInstallState, onInstallRequ
       InstallProgressLine(stringResource(Res.string.library_fetching))
     is RepertoireInstallState.Importing ->
       InstallProgressLine(stringResource(Res.string.library_importing))
-    is RepertoireInstallState.Installed -> {
-      val summary = installState.summary
-      if (summary != null) {
-        Text(
-          text =
-            stringResource(
-              Res.string.library_install_summary,
-              summary.movesAdded,
-              summary.movesAlreadyPresent,
-            ),
-          style = typography.bodySm.copy(color = palette.green),
-        )
+    is RepertoireInstallState.Installed ->
+      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        val summary = installState.summary
+        if (summary != null) {
+          Text(
+            text =
+              stringResource(
+                Res.string.library_install_summary,
+                summary.movesAdded,
+                summary.movesAlreadyPresent,
+              ),
+            style = typography.bodySm.copy(color = palette.green),
+          )
+        }
+        // Reinstalling restores moves the user has removed since installing.
+        KineticButton(onClick = onInstallRequest, style = KineticButtonStyle.Primary) {
+          KineticButtonLabel(stringResource(Res.string.library_reinstall))
+        }
       }
-    }
     is RepertoireInstallState.Failed ->
       Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(
@@ -384,9 +417,18 @@ private fun installErrorText(error: InstallError): String =
       stringResource(Res.string.library_install_error_import, error.message)
   }
 
-/** Metadata preview shown in the confirmation dialog before an install starts. */
+/**
+ * Metadata preview shown in the confirmation dialog before an install starts, including the live
+ * overlap of [previewState] (how many of the repertoire's moves the user already has).
+ *
+ * @param descriptor The repertoire being previewed.
+ * @param previewState Overlap computation state, or `null` while none has been published yet.
+ */
 @Composable
-private fun PreviewDialogContent(descriptor: RepertoireDescriptor) {
+private fun PreviewDialogContent(
+  descriptor: RepertoireDescriptor,
+  previewState: RepertoirePreviewState?,
+) {
   val palette = LocalKineticPalette.current
   val typography = LocalKineticTypography.current
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -407,9 +449,45 @@ private fun PreviewDialogContent(descriptor: RepertoireDescriptor) {
         ),
       style = typography.monoSm.copy(color = palette.ink3),
     )
+    PreviewOverlap(previewState)
     Text(
       text = stringResource(Res.string.library_preview_question),
       style = typography.bodySm.copy(color = palette.ink3),
     )
+  }
+}
+
+/**
+ * The "moves in common" line of the preview dialog. Renders a checking hint while the overlap loads
+ * (also the `null` not-yet-requested case), the count once ready, and a muted notice on failure so
+ * a download error never blocks the install. A repertoire with no moves shows nothing.
+ */
+@Composable
+private fun PreviewOverlap(previewState: RepertoirePreviewState?) {
+  val palette = LocalKineticPalette.current
+  val typography = LocalKineticTypography.current
+  when (previewState) {
+    null,
+    is RepertoirePreviewState.Loading ->
+      InstallProgressLine(stringResource(Res.string.library_preview_checking))
+    is RepertoirePreviewState.Ready -> {
+      val preview = previewState.preview
+      if (preview.totalMoves > 0) {
+        Text(
+          text =
+            stringResource(
+              Res.string.library_preview_in_common,
+              preview.movesInCommon,
+              preview.totalMoves,
+            ),
+          style = typography.bodySm.copy(color = palette.accentText),
+        )
+      }
+    }
+    is RepertoirePreviewState.Failed ->
+      Text(
+        text = stringResource(Res.string.library_preview_in_common_error),
+        style = typography.bodySm.copy(color = palette.ink3),
+      )
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/repertoire/TestRepertoireLibraryViewModel.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/repertoire/TestRepertoireLibraryViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.TestScope
 import proj.memorchess.axl.core.config.INSTALLED_REPERTOIRES_SETTING
 import proj.memorchess.axl.core.pgn.PgnGame
 import proj.memorchess.axl.core.pgn.PgnImportException
+import proj.memorchess.axl.core.pgn.PgnImportPreview
 import proj.memorchess.axl.core.pgn.PgnImportSummary
 import proj.memorchess.axl.test_util.TestWithKoin
 
@@ -44,8 +45,11 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
   private fun TestScope.buildViewModel(
     loadManifest: suspend () -> CachedManifestResult,
     fetchPgn: suspend (String) -> CatalogResult<List<PgnGame>> = { CatalogResult.Ok(emptyList()) },
-    importGames: suspend (List<PgnGame>) -> PgnImportSummary = {
+    importGames: suspend (RepertoireColor, List<PgnGame>) -> PgnImportSummary = { _, _ ->
       PgnImportSummary(movesAdded = 3, movesAlreadyPresent = 1)
+    },
+    previewGames: suspend (RepertoireColor, List<PgnGame>) -> PgnImportPreview = { _, _ ->
+      PgnImportPreview(totalMoves = 4, movesInCommon = 1)
     },
     store: InstalledRepertoireStore = InstalledRepertoireStore(),
   ) =
@@ -53,6 +57,7 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
       loadManifest = loadManifest,
       fetchPgn = fetchPgn,
       importGames = importGames,
+      previewGames = previewGames,
       installedStore = store,
       scope = backgroundScope,
     )
@@ -175,7 +180,7 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
     val viewModel =
       buildViewModel(
         { CachedManifestResult.Fresh(manifest(london)) },
-        importGames = { PgnImportSummary(movesAdded = 5, movesAlreadyPresent = 2) },
+        importGames = { _, _ -> PgnImportSummary(movesAdded = 5, movesAlreadyPresent = 2) },
         store = store,
       )
     viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
@@ -186,6 +191,25 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
     state[london.id] shouldBe
       RepertoireInstallState.Installed(PgnImportSummary(movesAdded = 5, movesAlreadyPresent = 2))
     store.isInstalled(london.id) shouldBe true
+  }
+
+  @Test
+  fun installForwardsTheRepertoireColorToTheImporter() = test {
+    var importedColor: RepertoireColor? = null
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(caroKann)) },
+        importGames = { color, _ ->
+          importedColor = color
+          PgnImportSummary(movesAdded = 1, movesAlreadyPresent = 0)
+        },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.install(caroKann)
+    viewModel.installStates.first { it[caroKann.id] is RepertoireInstallState.Installed }
+
+    importedColor shouldBe RepertoireColor.BLACK
   }
 
   @Test
@@ -248,7 +272,7 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
     val viewModel =
       buildViewModel(
         { CachedManifestResult.Fresh(manifest(london)) },
-        importGames = { throw PgnImportException("Illegal move Qx9 at ply 4 in game 1") },
+        importGames = { _, _ -> throw PgnImportException("Illegal move Qx9 at ply 4 in game 1") },
         store = store,
       )
     viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
@@ -287,7 +311,7 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
   }
 
   @Test
-  fun installOnAnAlreadyInstalledRepertoireIsIgnored() = test {
+  fun installOnAnAlreadyInstalledRepertoireReinstalls() = test {
     val store = InstalledRepertoireStore()
     store.markInstalled(london.id)
     var fetchCalls = 0
@@ -298,16 +322,73 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
           fetchCalls++
           CatalogResult.Ok(emptyList())
         },
+        importGames = { _, _ -> PgnImportSummary(movesAdded = 2, movesAlreadyPresent = 6) },
         store = store,
       )
     viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
-
-    viewModel.install(london)
-    testScheduler.advanceUntilIdle()
-
-    fetchCalls shouldBe 0
+    // The catalog seeds an Installed(summary = null) state from persistence.
     viewModel.installStates.value[london.id] shouldBe
       RepertoireInstallState.Installed(summary = null)
+
+    viewModel.install(london)
+    val state = viewModel.installStates.first { it[london.id] is RepertoireInstallState.Installed }
+
+    // Reinstall re-fetches and re-imports, restoring removed moves and reporting the fresh summary.
+    fetchCalls shouldBe 1
+    state[london.id] shouldBe
+      RepertoireInstallState.Installed(PgnImportSummary(movesAdded = 2, movesAlreadyPresent = 6))
+    store.isInstalled(london.id) shouldBe true
+  }
+
+  @Test
+  fun requestPreviewPublishesTheOverlap() = test {
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(caroKann)) },
+        fetchPgn = { CatalogResult.Ok(emptyList()) },
+        previewGames = { _, _ -> PgnImportPreview(totalMoves = 12, movesInCommon = 5) },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(caroKann)
+    val state = viewModel.previewStates.first { it[caroKann.id] is RepertoirePreviewState.Ready }
+
+    state[caroKann.id] shouldBe
+      RepertoirePreviewState.Ready(PgnImportPreview(totalMoves = 12, movesInCommon = 5))
+  }
+
+  @Test
+  fun requestPreviewForwardsTheRepertoireColor() = test {
+    var previewedColor: RepertoireColor? = null
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(caroKann)) },
+        previewGames = { color, _ ->
+          previewedColor = color
+          PgnImportPreview(totalMoves = 1, movesInCommon = 0)
+        },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(caroKann)
+    viewModel.previewStates.first { it[caroKann.id] is RepertoirePreviewState.Ready }
+
+    previewedColor shouldBe RepertoireColor.BLACK
+  }
+
+  @Test
+  fun requestPreviewSurfacesAFetchFailure() = test {
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(london)) },
+        fetchPgn = { CatalogResult.HttpError(404) },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(london)
+    val state = viewModel.previewStates.first { it[london.id] is RepertoirePreviewState.Failed }
+
+    state[london.id] shouldBe RepertoirePreviewState.Failed(InstallError.Http(404))
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/repertoire/TestRepertoireLibraryViewModel.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/repertoire/TestRepertoireLibraryViewModel.kt
@@ -392,6 +392,63 @@ class TestRepertoireLibraryViewModel : TestWithKoin() {
   }
 
   @Test
+  fun requestPreviewWhileOneIsLoadingIsIgnored() = test {
+    val gate = CompletableDeferred<Unit>()
+    var fetchCalls = 0
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(london)) },
+        fetchPgn = {
+          fetchCalls++
+          gate.await()
+          CatalogResult.Ok(emptyList())
+        },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(london)
+    viewModel.requestPreview(london)
+    gate.complete(Unit)
+    viewModel.previewStates.first { it[london.id] is RepertoirePreviewState.Ready }
+
+    fetchCalls shouldBe 1
+  }
+
+  @Test
+  fun requestPreviewSurfacesAComputationFailure() = test {
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(london)) },
+        fetchPgn = { CatalogResult.Ok(emptyList()) },
+        previewGames = { _, _ -> throw PgnImportException("Illegal move Qx9 at ply 4 in game 1") },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(london)
+    val state = viewModel.previewStates.first { it[london.id] is RepertoirePreviewState.Failed }
+
+    state[london.id] shouldBe
+      RepertoirePreviewState.Failed(
+        InstallError.ImportFailed("Illegal move Qx9 at ply 4 in game 1")
+      )
+  }
+
+  @Test
+  fun requestPreviewMapsAMalformedManifestToMalformedPgn() = test {
+    val viewModel =
+      buildViewModel(
+        { CachedManifestResult.Fresh(manifest(london)) },
+        fetchPgn = { CatalogResult.MalformedManifest("bad") },
+      )
+    viewModel.catalogState.first { it is LibraryCatalogState.Loaded }
+
+    viewModel.requestPreview(london)
+    val state = viewModel.previewStates.first { it[london.id] is RepertoirePreviewState.Failed }
+
+    state[london.id] shouldBe RepertoirePreviewState.Failed(InstallError.MalformedPgn("bad"))
+  }
+
+  @Test
   fun failedInstallCanBeRetriedToSuccess() = test {
     val store = InstalledRepertoireStore()
     var failNext = true

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/pgn/TestPgnImporter.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/pgn/TestPgnImporter.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.engine.GameEngine
+import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.core.scheduling.CardStateFactory
 import proj.memorchess.axl.test_util.TestDatabaseQueryManager
@@ -23,6 +24,10 @@ class TestPgnImporter {
     moves.forEach { engine.playSanMove(it) }
     return engine.toPositionKey()
   }
+
+  /** `isGood` of the persisted [move] leaving [from], or `null` when the move was not stored. */
+  private fun isGoodOf(from: PositionKey, move: String): Boolean? =
+    database.dataNodes[from]?.previousAndNextMoves?.nextMoves?.get(move)?.isGood
 
   @Test
   fun doubleImportIsIdempotent() = runTest {
@@ -110,6 +115,115 @@ class TestPgnImporter {
     assertEquals(setOf("e4", "d4"), startNode.previousAndNextMoves.nextMoves.keys)
     assertTrue(database.dataNodes.containsKey(keyAfter("e4", "e5")))
     assertTrue(database.dataNodes.containsKey(keyAfter("d4", "d5")))
+  }
+
+  @Test
+  fun blackPerspectiveMarksOnlyBlackMovesAsGood() = runTest {
+    // Arrange: the Scandinavian, a black repertoire.
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+
+    // Act
+    val summary = importer.import(games, perspective = Player.BLACK)
+
+    // Assert: white's moves are stored but not trainable, black's are the repertoire.
+    assertEquals(PgnImportSummary(movesAdded = 4, movesAlreadyPresent = 0), summary)
+    assertEquals(false, isGoodOf(keyAfter(), "e4"))
+    assertEquals(true, isGoodOf(keyAfter("e4"), "d5"))
+    assertEquals(false, isGoodOf(keyAfter("e4", "d5"), "exd5"))
+    assertEquals(true, isGoodOf(keyAfter("e4", "d5", "exd5"), "Qxd5"))
+  }
+
+  @Test
+  fun whitePerspectiveMarksOnlyWhiteMovesAsGood() = runTest {
+    // Arrange: the London System, a white repertoire.
+    val games = PgnParser.parse("1. d4 d5 2. Bf4 *")
+
+    // Act
+    val summary = importer.import(games, perspective = Player.WHITE)
+
+    // Assert
+    assertEquals(PgnImportSummary(movesAdded = 3, movesAlreadyPresent = 0), summary)
+    assertEquals(true, isGoodOf(keyAfter(), "d4"))
+    assertEquals(false, isGoodOf(keyAfter("d4"), "d5"))
+    assertEquals(true, isGoodOf(keyAfter("d4", "d5"), "Bf4"))
+  }
+
+  @Test
+  fun perspectiveImportIsIdempotent() = runTest {
+    // Arrange
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+
+    // Act
+    val firstSummary = importer.import(games, perspective = Player.BLACK)
+    val secondSummary = importer.import(games, perspective = Player.BLACK)
+
+    // Assert: re-importing the same one sided repertoire adds nothing, including opponent moves.
+    assertEquals(PgnImportSummary(movesAdded = 4, movesAlreadyPresent = 0), firstSummary)
+    assertEquals(PgnImportSummary(movesAdded = 0, movesAlreadyPresent = 4), secondSummary)
+  }
+
+  @Test
+  fun previewOnEmptyGraphReportsNoOverlap() = runTest {
+    // Arrange: nothing imported yet, so none of the repertoire's moves are in common.
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+
+    // Act
+    val preview = importer.preview(games, perspective = Player.BLACK)
+
+    // Assert
+    assertEquals(PgnImportPreview(totalMoves = 4, movesInCommon = 0), preview)
+  }
+
+  @Test
+  fun previewReportsPartialOverlap() = runTest {
+    // Arrange: import the trunk, then preview a repertoire that extends it.
+    importer.import(PgnParser.parse("1. e4 d5 *"), perspective = Player.BLACK)
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+
+    // Act
+    val preview = importer.preview(games, perspective = Player.BLACK)
+
+    // Assert: e4 and d5 already present, exd5 and Qxd5 are new.
+    assertEquals(PgnImportPreview(totalMoves = 4, movesInCommon = 2), preview)
+  }
+
+  @Test
+  fun previewReportsFullOverlapAfterInstall() = runTest {
+    // Arrange
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+    importer.import(games, perspective = Player.BLACK)
+
+    // Act
+    val preview = importer.preview(games, perspective = Player.BLACK)
+
+    // Assert: a fully installed repertoire has every move in common and writes nothing.
+    assertEquals(PgnImportPreview(totalMoves = 4, movesInCommon = 4), preview)
+  }
+
+  @Test
+  fun previewClassifiesByPerspectiveLikeImport() = runTest {
+    // Arrange: install for black, then preview the same PGN as a white repertoire.
+    val games = PgnParser.parse("1. e4 d5 2. exd5 Qxd5 *")
+    importer.import(games, perspective = Player.BLACK)
+
+    // Act: white's good moves (e4, exd5) are stored as not good, so none match.
+    val preview = importer.preview(games, perspective = Player.WHITE)
+
+    // Assert
+    assertEquals(PgnImportPreview(totalMoves = 4, movesInCommon = 0), preview)
+  }
+
+  @Test
+  fun previewDoesNotWriteAnything() = runTest {
+    // Arrange
+    val games = PgnParser.parse("1. e4 d5 *")
+
+    // Act
+    importer.preview(games, perspective = Player.BLACK)
+
+    // Assert
+    assertTrue(database.dataNodes.isEmpty())
+    assertTrue(store.current().snapshot().isEmpty())
   }
 
   @Test


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Summary

Fixes a bug where installing an opening repertoire taught moves for the wrong side, plus two related improvements requested alongside it.

### 1. Perspective-aware import (the bug)
Installing a repertoire marked **every** move as good (`isGood = true`), so a Black opening like the Scandinavian also made White's moves trainable — the user got quizzed on the opponent's moves.

`PgnImporter.import` now takes a `perspective: Player?`:
- the repertoire side's moves → `isGood = true` (drilled)
- the opponent's replies → `isGood = false` (stored so they thread the graph together, but never drilled) — exactly what the manual `LinesExplorer` save flow already produces
- `perspective = null` keeps the previous mark-everything-good behaviour, used by the two-sided Lichess study import (unchanged via the default)

The repertoire's `RepertoireColor` now flows from the descriptor through the view model to the importer.

### 2. Reinstall to restore removed moves
`install()` no longer bails out for an already-installed repertoire (only while a fetch/import is in flight). Reinstalling re-adds moves the user has since removed — the import skips moves still present. The installed card shows a **Reinstall** button.

### 3. "Moves in common" in the preview dialog
New non-writing `PgnImporter.preview()` dry run returns `PgnImportPreview(totalMoves, movesInCommon)` using the same perspective classification as `import`. When the user taps a repertoire, the confirm dialog fetches the PGN and shows *"X of Y moves already in your repertoire"* (with loading and failure states; failure never blocks install).

## Tests
- `TestPgnImporter`: black/white perspective classification (Scandinavian, London), perspective idempotency, and `preview` overlap at the 0 / partial / full boundaries + perspective-mismatch + no-write assertions.
- `TestRepertoireLibraryViewModel`: color forwarded to importer and to preview, reinstall re-fetches/re-imports, preview overlap publishing, and preview fetch-failure surfacing.

JVM test suite, `ktfmtCheck`, and JVM compile all pass. Full multiplatform build not run locally.

## Note for reviewers
Opponent moves reuse `isGood = false`, the same value the manual save flow produces. Functionally correct (threads positions without drilling them), though it slightly overloads `false`'s documented "mistake to counter" meaning. Happy to introduce a distinct third classification instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)