### PR TITLE
chore: add issue templates for bug reports and feature requests

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: create-issue
+description: Create a GitHub issue for MemorChess that mirrors the repo's bug-report / feature-request issue forms. Use when the user asks to open, file, or create a GitHub issue.
+---
+
+# Create issue
+
+Open a GitHub issue with `gh issue create`, structuring the body to match the
+repo's issue forms in `.github/ISSUE_TEMPLATE/`. The `.yml` forms only apply in
+the web UI, so when creating via CLI you must fill the same fields by hand.
+
+## Steps
+
+1. Decide the type from what the user is reporting:
+   - **Bug** — something is broken or behaves unexpectedly. Label `bug`.
+   - **Feature** — a new idea or improvement. Label `enhancement`.
+   If it's ambiguous, ask the user which one.
+2. Gather the fields below. If a required field is missing and you can't infer
+   it, ask the user a brief question rather than guessing.
+3. Create the issue:
+   ```sh
+   gh issue create --title "<title>" --label "<bug|enhancement>" --body "<body>"
+   ```
+4. Report the issue URL back to the user.
+
+## Bug body (mirror of `bug_report.yml`)
+
+```markdown
+### What happened?
+<description of the bug and expected behavior — required>
+
+### Steps to reproduce
+1. ...
+2. ...
+
+### Platform
+<Android | iOS | JVM desktop | WebAssembly (web) — required>
+
+### App version / commit
+<version or git commit, if known>
+
+### Logs or screenshots
+<relevant logs, stack traces, or screenshots, if any>
+```
+
+## Feature body (mirror of `feature_request.yml`)
+
+```markdown
+### Problem or motivation
+<what problem this solves or the motivation — required>
+
+### Proposed solution
+<the feature or behavior you'd like — required>
+
+### Affected platforms
+<Android | iOS | JVM desktop | WebAssembly (web) | All platforms>
+
+### Alternatives considered
+<alternative solutions or workarounds, if any>
+```
+
+## Notes
+
+- Keep the title concise; no Conventional Commits prefix is required for issues
+  (that rule is for PR titles only).
+- Omit optional sections that are empty rather than leaving placeholder text.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a problem with MemorChess
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a bug!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Where did you encounter the bug?
+      options:
+        - Android
+        - iOS
+        - JVM desktop
+        - WebAssembly (web)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version / commit
+      description: The release version or git commit you were running.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste any relevant logs, stack traces, or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea or improvement for MemorChess
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem would this feature solve, or what is the motivation behind it?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you would like to see.
+    validations:
+      required: true
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Affected platforms
+      description: Which platforms would this feature target?
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - JVM desktop
+        - WebAssembly (web)
+        - All platforms
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you have thought about.
+    validations:
+      required: false


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

---

Adds a `.github/ISSUE_TEMPLATE/` directory so the repo offers multiple structured issue templates via the GitHub chooser.

### What's included

- **`bug_report.yml`** — Issue Form with description, reproduction steps, platform dropdown (Android / iOS / JVM desktop / WebAssembly), version, and logs/screenshots.
- **`feature_request.yml`** — Issue Form with motivation, proposed solution, affected-platforms multi-select, and alternatives.
- **`config.yml`** — disables blank issues so contributors pick a template.

These use the modern Issue Forms (`.yml`) format with field validation. Kept lightweight since the app isn't in production yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)