### PR TITLE
fix(test): unstick wasm RepertoireView tests by yielding to the JS event loop

### DIFF
--- a/composeApp/karma.config.d/timeout.js
+++ b/composeApp/karma.config.d/timeout.js
@@ -1,10 +1,8 @@
 config.set({
   browserNoActivityTimeout: 120000,
   browserDisconnectTimeout: 30000,
-  // The single wasm thread can block the browser event loop (PGN parse, graph build, GC) long
-  // enough to miss a Karma heartbeat on a loaded CI runner. With the default tolerance of 0 a
-  // single missed ping fails the whole run with zero test failures (issue #228), so tolerate a
-  // few transient disconnects and give the socket more time before declaring the browser dead.
+  // Tolerate transient browser disconnects on a loaded CI runner; default tolerance of 0 fails the
+  // whole run on a single missed heartbeat with zero test failures (issue #228).
   browserDisconnectTolerance: 3,
   pingTimeout: 60000,
   client: {

--- a/composeApp/karma.config.d/timeout.js
+++ b/composeApp/karma.config.d/timeout.js
@@ -1,6 +1,12 @@
 config.set({
   browserNoActivityTimeout: 120000,
   browserDisconnectTimeout: 30000,
+  // The single wasm thread can block the browser event loop (PGN parse, graph build, GC) long
+  // enough to miss a Karma heartbeat on a loaded CI runner. With the default tolerance of 0 a
+  // single missed ping fails the whole run with zero test failures (issue #228), so tolerate a
+  // few transient disconnects and give the socket more time before declaring the browser dead.
+  browserDisconnectTolerance: 3,
+  pingTimeout: 60000,
   client: {
     mocha: {
       timeout: 60000

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
@@ -40,10 +40,5 @@ fun getPieceDescription(piece: String): String {
 
 val TEST_TIMEOUT = 10.seconds
 
-/**
- * Safety ceiling for a page that loads its board asynchronously (e.g. the repertoire viewer, which
- * fetches and parses a PGN in a `LaunchedEffect` before the board renders) to finish settling. The
- * load itself completes quickly once the poll loop yields to the event loop; this is generously
- * larger than [TEST_TIMEOUT] only so a genuinely slow host does not trip it spuriously.
- */
+/** Safety ceiling for an asynchronous board load to settle; generous so slow hosts don't flake. */
 val BOARD_LOAD_TIMEOUT = 30.seconds

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
@@ -39,3 +39,11 @@ fun getPieceDescription(piece: String): String {
 }
 
 val TEST_TIMEOUT = 10.seconds
+
+/**
+ * Safety ceiling for a page that loads its board asynchronously (e.g. the repertoire viewer, which
+ * fetches and parses a PGN in a `LaunchedEffect` before the board renders) to finish settling. The
+ * load itself completes quickly once the poll loop yields to the event loop; this is generously
+ * larger than [TEST_TIMEOUT] only so a genuinely slow host does not trip it spuriously.
+ */
+val BOARD_LOAD_TIMEOUT = 30.seconds

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
@@ -156,18 +156,12 @@ fun ComposeUiTest.isBoardReversed(): Boolean {
 }
 
 /**
- * Suspends until the chess board has rendered, i.e. a page that loads its board asynchronously
- * (such as the repertoire viewer, which fetches and parses a PGN over an HTTP client in a
- * `LaunchedEffect` before the board appears) has finished settling.
+ * Suspends until the board of an asynchronously loading page (e.g. the repertoire viewer, which
+ * fetches a PGN in a `LaunchedEffect`) has rendered.
  *
- * The poll loop must hand control back to the real JS event loop, which is what the
- * `withContext(Dispatchers.Default) {}` hop does. Ktor runs the `MockEngine` request on
- * [Dispatchers.Default]; under `runComposeUiTest`'s virtual-time test dispatcher neither
- * [ComposeUiTest.waitForIdle] nor [ComposeUiTest.awaitIdle] ever relinquish to that dispatcher, so
- * without the hop the `LaunchedEffect`'s HTTP continuation never runs and the board never appears.
- * That is the flake tracked in issue #228: on CI the loop occasionally yields by chance and the
- * test passes, but on slower hosts it deadlocks every time. [awaitIdle] then drains the
- * recomposition the resumed load triggered.
+ * The `withContext(Dispatchers.Default) {}` hop is load-bearing: Ktor runs the `MockEngine` request
+ * on [Dispatchers.Default], which `runComposeUiTest`'s virtual-time dispatcher never yields to, so
+ * without it the HTTP continuation starves and the board never appears (issue #228).
  *
  * @param timeOut The maximum time to wait for the board to render.
  */

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
@@ -161,7 +161,7 @@ fun ComposeUiTest.isBoardReversed(): Boolean {
  *
  * The `withContext(Dispatchers.Default) {}` hop is load-bearing: Ktor runs the `MockEngine` request
  * on [Dispatchers.Default], which `runComposeUiTest`'s virtual-time dispatcher never yields to, so
- * without it the HTTP continuation starves and the board never appears (issue #228).
+ * without it the HTTP continuation starves and the board never appears.
  *
  * @param timeOut The maximum time to wait for the board to render.
  */

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/UiTestUtils.kt
@@ -21,7 +21,10 @@ import androidx.compose.ui.test.waitUntilDoesNotExist
 import co.touchlab.kermit.Logger
 import kotlin.time.Duration
 import kotlin.time.TimeSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import proj.memorchess.axl.core.engine.ChessPiece
+import proj.memorchess.axl.test_util.BOARD_LOAD_TIMEOUT
 import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.getNextMoveDescription
 import proj.memorchess.axl.test_util.getTileDescription
@@ -150,6 +153,34 @@ fun ComposeUiTest.isBoardReversed(): Boolean {
   val a1y = waitUntilTileAppears("a1").fetchSemanticsNode().positionOnScreen.y
   val a8y = waitUntilTileAppears("a8").fetchSemanticsNode().positionOnScreen.y
   return a1y < a8y
+}
+
+/**
+ * Suspends until the chess board has rendered, i.e. a page that loads its board asynchronously
+ * (such as the repertoire viewer, which fetches and parses a PGN over an HTTP client in a
+ * `LaunchedEffect` before the board appears) has finished settling.
+ *
+ * The poll loop must hand control back to the real JS event loop, which is what the
+ * `withContext(Dispatchers.Default) {}` hop does. Ktor runs the `MockEngine` request on
+ * [Dispatchers.Default]; under `runComposeUiTest`'s virtual-time test dispatcher neither
+ * [ComposeUiTest.waitForIdle] nor [ComposeUiTest.awaitIdle] ever relinquish to that dispatcher, so
+ * without the hop the `LaunchedEffect`'s HTTP continuation never runs and the board never appears.
+ * That is the flake tracked in issue #228: on CI the loop occasionally yields by chance and the
+ * test passes, but on slower hosts it deadlocks every time. [awaitIdle] then drains the
+ * recomposition the resumed load triggered.
+ *
+ * @param timeOut The maximum time to wait for the board to render.
+ */
+suspend fun ComposeUiTest.waitUntilBoardAppears(timeOut: Duration = BOARD_LOAD_TIMEOUT) {
+  val matcher = hasClickLabel(getTileDescription("a1"))
+  val mark = TimeSource.Monotonic.markNow()
+  while (onAllNodes(matcher).fetchSemanticsNodes().isEmpty()) {
+    if (mark.elapsedNow() > timeOut) {
+      throw AssertionError("Board still not rendered after $timeOut")
+    }
+    withContext(Dispatchers.Default) {}
+    awaitIdle()
+  }
 }
 
 private fun ComposeUiTest.waitUntilTileAppears(tileName: String): SemanticsNodeInteraction {

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
@@ -29,6 +29,7 @@ import proj.memorchess.axl.ui.pages.RepertoireLibraryActions
 import proj.memorchess.axl.ui.pages.RepertoireLibraryContent
 import proj.memorchess.axl.ui.pages.RepertoireView
 import proj.memorchess.axl.ui.playMove
+import proj.memorchess.axl.ui.waitUntilBoardAppears
 
 @OptIn(ExperimentalTestApi::class)
 class TestRepertoireView : TestWithKoin() {
@@ -65,17 +66,23 @@ class TestRepertoireView : TestWithKoin() {
     return CachedRepertoireCatalog(client) to client
   }
 
-  private fun runViewer(pgn: String = "1. e4 e5 2. Nf3 *", block: ComposeUiTest.() -> Unit) =
-    runComposeUiTest {
-      koinSetUp()
-      try {
-        val (catalog, client) = mockCatalog(pgn)
-        setContent { InitializeApp { RepertoireView("test-rep", catalog, client) } }
-        block()
-      } finally {
-        koinTearDown()
-      }
+  private fun runViewer(
+    pgn: String = "1. e4 e5 2. Nf3 *",
+    block: suspend ComposeUiTest.() -> Unit,
+  ) = runComposeUiTest {
+    koinSetUp()
+    try {
+      val (catalog, client) = mockCatalog(pgn)
+      setContent { InitializeApp { RepertoireView("test-rep", catalog, client) } }
+      // RepertoireView fetches and parses the PGN over an HTTP client in a LaunchedEffect before
+      // the board renders. Suspend until the board appears so the MockEngine response actually
+      // runs on the JS event loop; the blocking waiters never yield to it on wasmJs (issue #228).
+      waitUntilBoardAppears()
+      block()
+    } finally {
+      koinTearDown()
     }
+  }
 
   @Test
   fun bookMoveCanBePlayed() = runViewer {

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/repertoire/TestRepertoireView.kt
@@ -74,9 +74,7 @@ class TestRepertoireView : TestWithKoin() {
     try {
       val (catalog, client) = mockCatalog(pgn)
       setContent { InitializeApp { RepertoireView("test-rep", catalog, client) } }
-      // RepertoireView fetches and parses the PGN over an HTTP client in a LaunchedEffect before
-      // the board renders. Suspend until the board appears so the MockEngine response actually
-      // runs on the JS event loop; the blocking waiters never yield to it on wasmJs (issue #228).
+      // Wait for the async PGN load to render the board before asserting (issue #228).
       waitUntilBoardAppears()
       block()
     } finally {


### PR DESCRIPTION
## Options

- [x] Force running tests
- [ ] Run benchmarks

> Forcing the full tier so the `wasm-tests` job actually runs — this fix targets it, but the changed paths (commonTest + karma config) otherwise resolve to the cheap tier where wasm is skipped.

## Summary

Fixes #228. The three board-rendering `TestRepertoireView` tests flaked on `:composeApp:wasmJsBrowserTest` (Firefox/Karma) with `ComposeTimeoutException` and passed on re-run. They reproduce **deterministically** on slower hosts, which made the real cause findable.

## Root cause

`RepertoireView` loads its PGN over a Ktor `MockEngine` inside a `LaunchedEffect`. Ktor runs that request on `Dispatchers.Default`. Under `runComposeUiTest`'s virtual-time test dispatcher, **none** of `waitForIdle()`, `awaitIdle()`, `waitUntilAtLeastOneExists`, or the suspending `waitUntilSuspending` ever relinquish to `Dispatchers.Default` — they only pump the Compose frame clock. So the HTTP continuation starves, the viewer never leaves `Loading`, and the board never renders. DB-backed waits work only because the in-memory test DB resumes on the pumped dispatcher.

Diagnostic logging confirmed the hang on the very first `httpClient.get()`. On CI the poll loop yields to the event loop by chance (~93% of runs pass); slower hosts deadlock every time.

## Changes

- **`UiTestUtils.waitUntilBoardAppears`** — new suspending gate whose poll loop does `withContext(Dispatchers.Default) {}` (hands control to the real JS event loop so the load completes) then `awaitIdle()` to drain the resulting recomposition. `runViewer`'s block is now `suspend` so it can call it.
- **`BOARD_LOAD_TIMEOUT`** — 30s safety ceiling for async board loads.
- **`karma.config.d/timeout.js`** — mitigates the second observed signature (browser ping-timeout disconnect with zero test failures): `browserDisconnectTolerance: 3` + `pingTimeout: 60000` so a single missed heartbeat no longer fails the whole run.

## Verification

- `./gradlew :composeApp:wasmJsBrowserTest` — full 366-test suite passes locally (was 3 deterministic failures on this host).
- `ktfmtCheck` clean; no production-code changes (`RepertoireView.kt` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)