### PR TITLE
perf(data): scheduler off the full graph (incremental loading phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ kotlin-js-store
 
 # Room schema export is disabled (exportSchema = false); these must never be committed.
 composeApp/schemas/
+docs/superpowers/

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/Koin.kt
@@ -68,6 +68,7 @@ fun initKoinModules(): Array<Module> {
     single { TreeStore(get()) }
     single {
       TrainingScheduler(
+        database = get(),
         treeStore = get(),
         algorithm = get(),
         maxNewMovesPerDay = { MAX_NEW_MOVES_PER_DAY_SETTING.getValue() },

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DataNode.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DataNode.kt
@@ -14,6 +14,12 @@ import proj.memorchess.axl.core.scheduling.CardState
  *   [proj.memorchess.axl.core.scheduling.SchedulingAlgorithm]. Holds the next due date and any
  *   algorithm specific state such as FSRS stability and difficulty.
  * @property depth The minimum depth at which this position can be reached from the root.
+ * @property hasGoodOutgoing Derived projection owned by [proj.memorchess.axl.core.graph.TreeStore]:
+ *   `true` iff this node has at least one non deleted outgoing edge marked good. Maintained on
+ *   every write and excluded from equality because it is recomputed from the node's outgoing edges.
+ * @property createdAt Derived projection owned by [proj.memorchess.axl.core.graph.TreeStore]: the
+ *   moment the position was first added, taken from the earliest non deleted incoming edge. Used as
+ *   the new card ordering tiebreak after [depth] and excluded from equality like [updatedAt].
  * @constructor Creates a new node.
  */
 data class DataNode(
@@ -23,6 +29,8 @@ data class DataNode(
   val depth: Int = 0,
   val updatedAt: Instant = DateUtil.now(),
   val isDeleted: Boolean = false,
+  val hasGoodOutgoing: Boolean = false,
+  val createdAt: Instant = DateUtil.now(),
 ) {
 
   override fun equals(other: Any?) =

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
@@ -2,6 +2,7 @@ package proj.memorchess.axl.core.data
 
 import kotlin.time.Instant
 import proj.memorchess.axl.core.graph.DeleteMode
+import proj.memorchess.axl.core.graph.TrainingEntry
 
 /**
  * Low level persistence seam for the opening tree.
@@ -51,4 +52,81 @@ interface DatabaseQueryManager {
 
   /** Retrieves the latest `updatedAt` across nodes and moves. */
   suspend fun getLastUpdate(): Instant?
+
+  /**
+   * Bounded `LIMIT 1` lookup of the next ready in session card.
+   *
+   * Returns the trainable card currently mid learning whose due date has already arrived, ordered
+   * by the earliest due date, or `null` when none qualifies. Predicate: `hasGoodOutgoing AND phase
+   * IN (LEARNING, RELEARNING) AND dueDate <= now`, ordered by `dueDate ASC`. Soft deleted rows are
+   * excluded. No edges are loaded; only the columns a
+   * [proj.memorchess.axl.core.graph.TrainingEntry] needs are read.
+   *
+   * @param now Current instant. The due bound is inclusive, so a card due exactly at [now]
+   *   qualifies.
+   */
+  suspend fun nextReadyLearningCard(now: Instant): TrainingEntry?
+
+  /**
+   * Bounded `LIMIT 1` lookup of the next pending in session card.
+   *
+   * Returns the trainable card currently mid learning whose due date is still in the future,
+   * ordered by the earliest due date, or `null` when none qualifies. Predicate: `hasGoodOutgoing
+   * AND phase IN (LEARNING, RELEARNING) AND dueDate > now`, ordered by `dueDate ASC`. Soft deleted
+   * rows are excluded.
+   *
+   * @param now Current instant. The due bound is strict, so a card due exactly at [now] does not
+   *   qualify (it is ready, not pending).
+   */
+  suspend fun nextPendingLearningCard(now: Instant): TrainingEntry?
+
+  /**
+   * Bounded `LIMIT 1` lookup of the next due review card.
+   *
+   * Returns the trainable graduated card due on or before the day, shallowest first, or `null` when
+   * none qualifies. Predicate: `hasGoodOutgoing AND phase = REVIEW AND dueDate < dayEndExclusive`,
+   * ordered by `depth ASC`. Soft deleted rows are excluded.
+   *
+   * @param dayEndExclusive Start of the day after the target day. A card due exactly at this
+   *   instant belongs to the next day and is excluded.
+   */
+  suspend fun nextDueReviewCard(dayEndExclusive: Instant): TrainingEntry?
+
+  /**
+   * Bounded `LIMIT 1` lookup of the next due new card.
+   *
+   * Returns the trainable brand new card due on or before the day, shallowest first with ties
+   * broken by the earliest creation, or `null` when none qualifies. Predicate: `hasGoodOutgoing AND
+   * phase = NEW AND dueDate < dayEndExclusive`, ordered by `depth ASC, createdAt ASC`. Soft deleted
+   * rows are excluded.
+   *
+   * @param dayEndExclusive Start of the day after the target day. A card due exactly at this
+   *   instant belongs to the next day and is excluded.
+   */
+  suspend fun nextDueNewCard(dayEndExclusive: Instant): TrainingEntry?
+
+  /**
+   * Computes the day's bounded scheduling tallies as five `COUNT(*)` queries over indexed
+   * predicates. No row set crosses the seam. See [SchedulingCounts] for each field's predicate.
+   *
+   * @param dayStart Start of the target calendar day in the active time zone.
+   * @param dayEndExclusive Start of the following day, used as the exclusive upper bound for all
+   *   day windowed predicates.
+   */
+  suspend fun getSchedulingCounts(dayStart: Instant, dayEndExclusive: Instant): SchedulingCounts
+
+  /**
+   * Bounded lookup of the first eligible card among an explicit, bounded set of positions.
+   *
+   * Used to find the next position to train after the current one without enumerating the graph:
+   * the caller supplies the current node's outgoing destinations (bounded by the branching factor).
+   * A position is eligible when it is trainable and either mid learning or due on or before the
+   * day: `positionKey IN (keys) AND hasGoodOutgoing AND (phase IN (LEARNING, RELEARNING) OR dueDate
+   * < dayEndExclusive)`. Soft deleted rows are excluded. Returns the first eligible entry, or
+   * `null` when [keys] is empty or none qualify.
+   *
+   * @param keys The bounded set of candidate positions to consider.
+   * @param dayEndExclusive Start of the day after the target day, the exclusive due bound.
+   */
+  suspend fun findEligibleAmong(keys: List<PositionKey>, dayEndExclusive: Instant): TrainingEntry?
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -3,6 +3,8 @@ package proj.memorchess.axl.core.data
 import kotlin.time.Instant
 import proj.memorchess.axl.core.graph.DeleteMode
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.graph.TrainingEntry
+import proj.memorchess.axl.core.scheduling.CardPhase
 
 /**
  * In memory [DatabaseQueryManager] with no persistence at all.
@@ -76,6 +78,94 @@ class InMemoryDatabaseQueryManager : DatabaseQueryManager {
         listOf(node.updatedAt) + (moves.previousMoves + moves.nextMoves).values.map { it.updatedAt }
       }
       .maxOrNull()
+
+  /**
+   * Live (non soft deleted) rows. Iterating the backing map is acceptable here precisely because
+   * this is the throwaway in memory store, not the disk backed path: the same predicates are
+   * expressed as bounded indexed queries on the Room and IndexedDB backends.
+   */
+  private fun live(): List<DataNode> = nodes.values.filter { !it.isDeleted }
+
+  private fun DataNode.isInSession(): Boolean =
+    cardState.phase == CardPhase.LEARNING || cardState.phase == CardPhase.RELEARNING
+
+  private fun DataNode.toTrainingEntry(): TrainingEntry = TrainingEntry(positionKey, cardState)
+
+  override suspend fun nextReadyLearningCard(now: Instant): TrainingEntry? =
+    live()
+      .filter { it.hasGoodOutgoing && it.isInSession() && it.cardState.dueDate <= now }
+      .minByOrNull { it.cardState.dueDate }
+      ?.toTrainingEntry()
+
+  override suspend fun nextPendingLearningCard(now: Instant): TrainingEntry? =
+    live()
+      .filter { it.hasGoodOutgoing && it.isInSession() && it.cardState.dueDate > now }
+      .minByOrNull { it.cardState.dueDate }
+      ?.toTrainingEntry()
+
+  override suspend fun nextDueReviewCard(dayEndExclusive: Instant): TrainingEntry? =
+    live()
+      .filter {
+        it.hasGoodOutgoing &&
+          it.cardState.phase == CardPhase.REVIEW &&
+          it.cardState.dueDate < dayEndExclusive
+      }
+      .minByOrNull { it.depth }
+      ?.toTrainingEntry()
+
+  override suspend fun nextDueNewCard(dayEndExclusive: Instant): TrainingEntry? =
+    live()
+      .filter {
+        it.hasGoodOutgoing &&
+          it.cardState.phase == CardPhase.NEW &&
+          it.cardState.dueDate < dayEndExclusive
+      }
+      .minWithOrNull(compareBy({ it.depth }, { it.createdAt }))
+      ?.toTrainingEntry()
+
+  override suspend fun getSchedulingCounts(
+    dayStart: Instant,
+    dayEndExclusive: Instant,
+  ): SchedulingCounts {
+    val live = live()
+    return SchedulingCounts(
+      introducedToday =
+        live.count {
+          it.cardState.firstReview?.let { f -> f >= dayStart && f < dayEndExclusive } == true
+        },
+      trainedToday =
+        live.count {
+          it.cardState.lastReview?.let { l -> l >= dayStart && l < dayEndExclusive } == true
+        },
+      dueReviews =
+        live.count {
+          it.hasGoodOutgoing &&
+            it.cardState.phase == CardPhase.REVIEW &&
+            it.cardState.dueDate < dayEndExclusive
+        },
+      dueNew =
+        live.count {
+          it.hasGoodOutgoing &&
+            it.cardState.phase == CardPhase.NEW &&
+            it.cardState.dueDate < dayEndExclusive
+        },
+      inSession = live.count { it.hasGoodOutgoing && it.isInSession() },
+    )
+  }
+
+  override suspend fun findEligibleAmong(
+    keys: List<PositionKey>,
+    dayEndExclusive: Instant,
+  ): TrainingEntry? =
+    keys
+      .firstNotNullOfOrNull { key ->
+        nodes[key]?.takeIf {
+          !it.isDeleted &&
+            it.hasGoodOutgoing &&
+            (it.isInSession() || it.cardState.dueDate < dayEndExclusive)
+        }
+      }
+      ?.toTrainingEntry()
 
   private fun PreviousAndNextMoves.withoutNext(
     move: String,

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/SchedulingCounts.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/SchedulingCounts.kt
@@ -1,0 +1,29 @@
+package proj.memorchess.axl.core.data
+
+/**
+ * Bounded daily scheduling tallies for a single calendar day.
+ *
+ * Every field is a `COUNT(*)` over an indexed predicate. No row set crosses the persistence seam to
+ * produce these numbers, so the cost is constant regardless of repertoire size. Computed by
+ * [DatabaseQueryManager.getSchedulingCounts] and consumed by
+ * [proj.memorchess.axl.core.graph.TrainingScheduler] to enforce the daily caps and report the
+ * pending count without ever enumerating the graph.
+ *
+ * @property introducedToday Number of cards whose `firstReview` falls inside the day window
+ *   `[dayStart, dayEndExclusive)`. Drives the new card cap.
+ * @property trainedToday Number of cards whose `lastReview` falls inside the day window `[dayStart,
+ *   dayEndExclusive)`. Drives the total reviews cap.
+ * @property dueReviews Number of trainable graduated cards due on or before the day:
+ *   `hasGoodOutgoing AND phase = REVIEW AND dueDate < dayEndExclusive`.
+ * @property dueNew Number of trainable brand new cards due on or before the day: `hasGoodOutgoing
+ *   AND phase = NEW AND dueDate < dayEndExclusive`.
+ * @property inSession Number of trainable cards currently mid learning: `hasGoodOutgoing AND phase
+ *   IN (LEARNING, RELEARNING)`. These are exempt from the daily caps.
+ */
+data class SchedulingCounts(
+  val introducedToday: Int,
+  val trainedToday: Int,
+  val dueReviews: Int,
+  val dueNew: Int,
+  val inSession: Int,
+)

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.plus
 import proj.memorchess.axl.core.data.DatabaseQueryManager
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.date.DateUtil
+import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.ReviewGrade
 import proj.memorchess.axl.core.scheduling.SchedulingAlgorithm
 
@@ -104,12 +105,27 @@ class TrainingScheduler(
    * Resolves [position]'s outgoing destinations (bounded by the branching factor) from the cache,
    * then asks the database for the first eligible one through
    * [DatabaseQueryManager.findEligibleAmong] so no graph enumeration happens.
+   *
+   * The daily caps are enforced here too, so staying in the current line cannot introduce more new
+   * cards than [maxNewMovesPerDay] or train more than [maxTotalMovesPerDay] allows. A single
+   * [DatabaseQueryManager.getSchedulingCounts] call establishes the day's remaining budgets: when
+   * the total budget is exhausted nothing is returned, and a brand new
+   * ([proj.memorchess.axl.core.scheduling.CardPhase.NEW]) candidate is withheld once the new budget
+   * is exhausted. In-session and review candidates only need the total budget to remain. The cost
+   * stays bounded: one counts call plus the single [DatabaseQueryManager.findEligibleAmong] lookup,
+   * never a graph walk.
    */
   suspend fun nextAfter(position: PositionKey, day: LocalDate = DateUtil.today()): TrainingEntry? {
     val node = treeStore.current().get(position) ?: return null
     val destinations = node.outgoing.values.map { it.to }
-    val (_, dayEnd) = dayBounds(day)
-    return database.findEligibleAmong(destinations, dayEnd)
+    val (dayStart, dayEnd) = dayBounds(day)
+    val counts = database.getSchedulingCounts(dayStart, dayEnd)
+    val totalRemaining = (maxTotalMovesPerDay() - counts.trainedToday).coerceAtLeast(0)
+    if (totalRemaining <= 0) return null
+    val newRemaining = (maxNewMovesPerDay() - counts.introducedToday).coerceAtLeast(0)
+    val candidate = database.findEligibleAmong(destinations, dayEnd) ?: return null
+    if (candidate.cardState.phase == CardPhase.NEW && newRemaining <= 0) return null
+    return candidate
   }
 
   /**

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TrainingScheduler.kt
@@ -1,41 +1,47 @@
 package proj.memorchess.axl.core.graph
 
 import kotlin.time.Instant
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
+import proj.memorchess.axl.core.data.DatabaseQueryManager
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.date.DateUtil
-import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.ReviewGrade
 import proj.memorchess.axl.core.scheduling.SchedulingAlgorithm
 
 /**
  * Spaced repetition driver for the opening tree.
  *
- * Reads the cached graph through [TreeStore.current] to enumerate trainable positions, asks
- * [SchedulingAlgorithm] for the next state after a review, and writes the result back through
- * [TreeStore.updateCardState]. Holds no graph state of its own.
+ * Drives entirely off the bounded scheduling surface of [DatabaseQueryManager]: a single
+ * [DatabaseQueryManager.getSchedulingCounts] call plus a constant number of `LIMIT 1` lookups per
+ * selection. It holds no graph and never enumerates the repertoire, so its cost stays constant no
+ * matter how large the repertoire grows. Writing a review result back goes through [TreeStore],
+ * which owns the only mutation path.
  *
- * A position is trainable when it has at least one outgoing edge marked as good.
+ * A position is trainable when it has at least one outgoing edge marked as good, captured by the
+ * derived `hasGoodOutgoing` column the queries filter on.
  *
  * Two daily caps bound a session, both counted on distinct positions within the calendar day in
  * [timeZone]:
  * - [maxNewMovesPerDay] caps positions whose very first review happens today, counted through
- *   [CardState.firstReview][proj.memorchess.axl.core.scheduling.CardState.firstReview];
+ *   [proj.memorchess.axl.core.data.SchedulingCounts.introducedToday];
  * - [maxTotalMovesPerDay] caps everything trained today, counted through
- *   [CardState.lastReview][proj.memorchess.axl.core.scheduling.CardState.lastReview].
+ *   [proj.memorchess.axl.core.data.SchedulingCounts.trainedToday].
  *
  * Cards mid learning steps are exempt: like Anki, a card that entered the session finishes its
- * sub-day steps even when the caps are reached. The counts derive from the card states on every
- * call, so they reset at local midnight on their own. Training ahead (passing a future [day]) gets
- * a fresh budget for that day by design, matching Anki's study-ahead behavior.
+ * sub-day steps even when the caps are reached. The counts derive from the persisted card states on
+ * every call, so they reset at local midnight on their own. Training ahead (passing a future [day])
+ * gets a fresh budget for that day by design, matching Anki's study-ahead behavior.
  *
  * The caps are suppliers rather than flat values so a settings change takes effect immediately on
  * the long lived singleton; defaults are unlimited so that direct construction stays usable without
  * any configuration wiring.
  */
 class TrainingScheduler(
+  private val database: DatabaseQueryManager,
   private val treeStore: TreeStore,
   private val algorithm: SchedulingAlgorithm,
   private val timeZone: TimeZone = TimeZone.currentSystemDefault(),
@@ -46,67 +52,87 @@ class TrainingScheduler(
   /**
    * Returns the next [TrainingEntry] to train, or `null` when there is nothing left for [day].
    *
-   * Selection runs in four tiers so that the in-session learning loop drains in step order without
-   * starving the day's review queue:
+   * One [DatabaseQueryManager.getSchedulingCounts] call establishes the day's remaining budgets,
+   * then the four bounded query tiers are asked in order so the in-session learning loop drains in
+   * step order without starving the day's review queue:
    * 1. **Ready learning cards** — a [proj.memorchess.axl.core.scheduling.CardPhase.LEARNING] or
    *    `RELEARNING` card whose sub-day due moment has arrived. The earliest due wins, so a card on
-   *    a one minute step surfaces before one on a ten minute step.
+   *    a one minute step surfaces before one on a ten minute step. Exempt from the caps.
    * 2. **Review cards** due on or before [day] — picked by smallest graph depth to follow the
-   *    natural opening order.
-   * 3. **New cards** due on or before [day] — picked by [OpeningTree.introductionOrder], so a whole
-   *    line is introduced before the next branch starts, in the order the lines were added to the
-   *    repertoire.
+   *    natural opening order. Consumes the total budget.
+   * 3. **New cards** due on or before [day] — picked by `depth ASC, createdAt ASC`, so shallower
+   *    positions surface first with ties broken by when the position was first added. Consumes the
+   *    new ∩ total budget.
    * 4. **Pending learning cards** — sub-day cards not yet due. Falling through to these guarantees
    *    a just-failed card always resurfaces in the same session rather than ending it early, again
-   *    earliest-due first.
+   *    earliest-due first. Exempt from the caps.
    *
    * The entry is **not** removed from the schedule: a card leaves the session only when [grade]
    * graduates it to a day grained review interval.
    */
-  fun nextDue(day: LocalDate = DateUtil.today()): TrainingEntry? {
+  suspend fun nextDue(day: LocalDate = DateUtil.today()): TrainingEntry? {
     val now = DateUtil.now()
-    val candidates = cappedCandidates(day)
-    if (candidates.isEmpty()) return null
+    val (dayStart, dayEnd) = dayBounds(day)
+    val counts = database.getSchedulingCounts(dayStart, dayEnd)
+    val newRemaining = (maxNewMovesPerDay() - counts.introducedToday).coerceAtLeast(0)
+    val totalRemaining = (maxTotalMovesPerDay() - counts.trainedToday).coerceAtLeast(0)
 
-    val readyLearning = candidates.filter {
-      it.cardState.isInSession() && it.cardState.dueDate <= now
+    // Tier 1: in-session, due now — exempt from caps.
+    database.nextReadyLearningCard(now)?.let {
+      return it
     }
-    if (readyLearning.isNotEmpty()) return readyLearning.minByOrNull { it.cardState.dueDate }
-
-    val reviewLike = candidates.filterNot { it.cardState.isInSession() }
-    val reviews = reviewLike.filter { it.cardState.phase == CardPhase.REVIEW }
-    if (reviews.isNotEmpty()) {
-      return reviews.minByOrNull { treeStore.current().getDepth(it.positionKey) }
+    // Tier 2: due reviews — consume total budget.
+    if (totalRemaining > 0) {
+      database.nextDueReviewCard(dayEnd)?.let {
+        return it
+      }
     }
-
-    val newCards = reviewLike.filter { it.cardState.phase == CardPhase.NEW }
-    if (newCards.isNotEmpty()) {
-      val order = treeStore.current().introductionOrder()
-      return newCards.minByOrNull { order[it.positionKey] ?: Int.MAX_VALUE }
+    // Tier 3: due new — consume new ∩ total budget.
+    if (newRemaining > 0 && totalRemaining > 0) {
+      database.nextDueNewCard(dayEnd)?.let {
+        return it
+      }
     }
-
-    return candidates.minByOrNull { it.cardState.dueDate }
+    // Tier 4: in-session, not yet due — exempt from caps.
+    return database.nextPendingLearningCard(now)
   }
 
   /**
-   * Returns a trainable entry reachable from one of [position]'s outgoing edges. Picking such an
-   * entry preserves the natural opening order during a session.
+   * Returns a trainable entry reachable from one of [position]'s outgoing edges, or `null` when
+   * none qualifies. Picking such an entry preserves the natural opening order during a session.
+   *
+   * Resolves [position]'s outgoing destinations (bounded by the branching factor) from the cache,
+   * then asks the database for the first eligible one through
+   * [DatabaseQueryManager.findEligibleAmong] so no graph enumeration happens.
    */
-  fun nextAfter(position: PositionKey, day: LocalDate = DateUtil.today()): TrainingEntry? {
+  suspend fun nextAfter(position: PositionKey, day: LocalDate = DateUtil.today()): TrainingEntry? {
     val node = treeStore.current().get(position) ?: return null
-    val reachable = node.outgoing.values.map { it.to }.toSet()
-    return cappedCandidates(day).firstOrNull { it.positionKey in reachable }
+    val destinations = node.outgoing.values.map { it.to }
+    val (_, dayEnd) = dayBounds(day)
+    return database.findEligibleAmong(destinations, dayEnd)
   }
 
   /**
-   * Counts entries still to train for [day]: review/new cards due plus any in-session card. The
-   * count honors the daily caps, so the UI shows what the trainer will actually serve.
+   * Counts entries still to train for [day]: in-session cards plus the servable due reviews and new
+   * cards once the daily caps are applied. Computed from a single
+   * [DatabaseQueryManager.getSchedulingCounts] call, so its cost is constant regardless of
+   * repertoire size, and it reports what the trainer will actually serve.
    */
-  fun pendingCount(day: LocalDate = DateUtil.today()): Int = cappedCandidates(day).size
+  suspend fun pendingCount(day: LocalDate = DateUtil.today()): Int {
+    val (dayStart, dayEnd) = dayBounds(day)
+    val c = database.getSchedulingCounts(dayStart, dayEnd)
+    val totalRemaining = (maxTotalMovesPerDay() - c.trainedToday).coerceAtLeast(0)
+    val newRemaining = (maxNewMovesPerDay() - c.introducedToday).coerceAtLeast(0)
+    val reviewsServable = minOf(c.dueReviews, totalRemaining)
+    val newBudget = minOf(newRemaining, totalRemaining - reviewsServable).coerceAtLeast(0)
+    val newServable = minOf(c.dueNew, newBudget)
+    return c.inSession + reviewsServable + newServable
+  }
 
   /**
-   * Persists the result of a review for [position]. Computes the next [CardState][CardState]
-   * through [SchedulingAlgorithm] and stores it through [TreeStore].
+   * Persists the result of a review for [position]. Computes the next
+   * [proj.memorchess.axl.core.scheduling.CardState] through [SchedulingAlgorithm] and stores it
+   * through [TreeStore].
    */
   suspend fun grade(position: PositionKey, grade: ReviewGrade) {
     val node = treeStore.current().get(position) ?: return
@@ -116,54 +142,15 @@ class TrainingScheduler(
   }
 
   /**
-   * The candidates for [day] after applying the daily caps.
+   * Computes the half open day window `[dayStart, dayEndExclusive)` for [day] in [timeZone].
    *
-   * In-session learning cards are always kept so they can finish their sub-day steps. Due review
-   * cards consume the total budget first, smallest depth first; due new cards then take whatever is
-   * left of both the new card budget and the total budget, in introduction order.
+   * `dayStart` is local midnight of [day]; `dayEndExclusive` is local midnight of the following
+   * day. "Due on or before [day]" is `dueDate < dayEndExclusive`; "happened on [day]" is `>=
+   * dayStart && < dayEndExclusive`.
    */
-  private fun cappedCandidates(day: LocalDate): List<TrainingEntry> {
-    val tree = treeStore.current()
-    val cardStates = tree.snapshot().values.map { it.cardState }
-    val introducedToday = cardStates.count { it.firstReview.isOn(day) }
-    val trainedToday = cardStates.count { it.lastReview.isOn(day) }
-    val newRemaining = (maxNewMovesPerDay() - introducedToday).coerceAtLeast(0)
-    val totalRemaining = (maxTotalMovesPerDay() - trainedToday).coerceAtLeast(0)
-
-    val all = candidates(day).toList()
-    val inSession = all.filter { it.cardState.isInSession() }
-    val reviews =
-      all
-        .filter { !it.cardState.isInSession() && it.cardState.phase == CardPhase.REVIEW }
-        .sortedBy { tree.getDepth(it.positionKey) }
-        .take(totalRemaining)
-    val newBudget = minOf(newRemaining, totalRemaining - reviews.size).coerceAtLeast(0)
-    val newCards =
-      if (newBudget == 0) emptyList()
-      else {
-        val order = tree.introductionOrder()
-        all
-          .filter { it.cardState.phase == CardPhase.NEW }
-          .sortedBy { order[it.positionKey] ?: Int.MAX_VALUE }
-          .take(newBudget)
-      }
-    return inSession + reviews + newCards
+  private fun dayBounds(day: LocalDate): Pair<Instant, Instant> {
+    val dayStart = day.atStartOfDayIn(timeZone)
+    val dayEndExclusive = day.plus(1, DateTimeUnit.DAY).atStartOfDayIn(timeZone)
+    return dayStart to dayEndExclusive
   }
-
-  private fun Instant?.isOn(day: LocalDate): Boolean =
-    this != null && toLocalDateTime(timeZone).date == day
-
-  /**
-   * Positions eligible to train for [day]. A position qualifies when it has at least one good
-   * outgoing edge and is either an in-session learning card (always eligible until it graduates) or
-   * a review/new card due on or before [day].
-   */
-  private fun candidates(day: LocalDate): Sequence<TrainingEntry> =
-    treeStore.current().snapshot().values.asSequence().mapNotNull { node ->
-      val hasGoodOutgoing = node.outgoing.values.any { it.isGood == true && !it.isDeleted }
-      if (!hasGoodOutgoing) return@mapNotNull null
-      val card = node.cardState
-      val eligible = card.isInSession() || card.dueLocalDate(timeZone) <= day
-      if (!eligible) null else TrainingEntry(node.positionKey, card)
-    }
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -178,7 +178,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
   suspend fun deleteMove(from: PositionKey, move: String, mode: DeleteMode = DeleteMode.HARD) {
     tree.removeEdge(from, move)
     database.deleteMove(from, move, mode)
-    persistSurvivingNode(from)
+    persistNode(from)
   }
 
   /**
@@ -201,7 +201,7 @@ class TreeStore(private val database: DatabaseQueryManager) {
     // Re-persist the origins that lost an outgoing edge so their derived hasGoodOutgoing flag
     // reflects the deletion and cannot go stale.
     for (origin in survivingOrigins) {
-      persistSurvivingNode(origin)
+      persistNode(origin)
     }
   }
 
@@ -211,18 +211,12 @@ class TreeStore(private val database: DatabaseQueryManager) {
     tree.clear()
   }
 
-  private suspend fun persistNode(positionKey: PositionKey) {
-    val node = tree[positionKey] ?: return
-    database.insertNodes(node.toDataNode())
-  }
-
   /**
-   * Re-persists [positionKey] after an edge removal so its derived projection column
-   * [DataNode.hasGoodOutgoing] cannot go stale. The origin row survives the edge deletion on disk,
-   * so it must be rewritten to reflect that it may no longer have any good outgoing edge. No write
-   * happens when the node is gone from the cache (it was itself the deleted node).
+   * Persists the cached node at [positionKey], if present. A no-op when the node is gone from the
+   * cache (e.g. it was itself just deleted), so it is safe to call after an edge removal to refresh
+   * a surviving endpoint's derived [DataNode.hasGoodOutgoing] flag.
    */
-  private suspend fun persistSurvivingNode(positionKey: PositionKey) {
+  private suspend fun persistNode(positionKey: PositionKey) {
     val node = tree[positionKey] ?: return
     database.insertNodes(node.toDataNode())
   }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -283,6 +283,8 @@ private fun Node.toDataNode(): DataNode =
     cardState = cardState,
     depth = depth,
     hasGoodOutgoing = outgoing.values.any { it.isGood == true && !it.isDeleted },
+    createdAt =
+      incoming.values.filter { !it.isDeleted }.minOfOrNull { it.createdAt } ?: DateUtil.now(),
     updatedAt = DateUtil.now(),
   )
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/TreeStore.kt
@@ -168,10 +168,17 @@ class TreeStore(private val database: DatabaseQueryManager) {
     persistNode(positionKey)
   }
 
-  /** Deletes the move [move] leaving [from] in both the cache and the underlying database. */
+  /**
+   * Deletes the move [move] leaving [from] in both the cache and the underlying database.
+   *
+   * After the cache edge is gone, the surviving [from] node is re-persisted so its derived
+   * [DataNode.hasGoodOutgoing] cannot go stale: deleting the last good edge must flip the flag back
+   * to `false`.
+   */
   suspend fun deleteMove(from: PositionKey, move: String, mode: DeleteMode = DeleteMode.HARD) {
     tree.removeEdge(from, move)
     database.deleteMove(from, move, mode)
+    persistSurvivingNode(from)
   }
 
   /**
@@ -179,16 +186,23 @@ class TreeStore(private val database: DatabaseQueryManager) {
    */
   suspend fun deleteNode(positionKey: PositionKey, mode: DeleteMode = DeleteMode.HARD) {
     val node = tree[positionKey]
+    val survivingOrigins = mutableSetOf<PositionKey>()
     if (node != null) {
       for (edge in node.outgoing.values.toList()) {
         tree.removeEdge(positionKey, edge.move)
       }
       for (edge in node.incoming.values.toList()) {
         tree.removeEdge(edge.from, edge.move)
+        survivingOrigins += edge.from
       }
       tree.removeNode(positionKey)
     }
     database.deletePosition(positionKey, mode)
+    // Re-persist the origins that lost an outgoing edge so their derived hasGoodOutgoing flag
+    // reflects the deletion and cannot go stale.
+    for (origin in survivingOrigins) {
+      persistSurvivingNode(origin)
+    }
   }
 
   /** Hard wipes every position and move, both in the cache and on disk. */
@@ -198,6 +212,17 @@ class TreeStore(private val database: DatabaseQueryManager) {
   }
 
   private suspend fun persistNode(positionKey: PositionKey) {
+    val node = tree[positionKey] ?: return
+    database.insertNodes(node.toDataNode())
+  }
+
+  /**
+   * Re-persists [positionKey] after an edge removal so its derived projection column
+   * [DataNode.hasGoodOutgoing] cannot go stale. The origin row survives the edge deletion on disk,
+   * so it must be rewritten to reflect that it may no longer have any good outgoing edge. No write
+   * happens when the node is gone from the cache (it was itself the deleted node).
+   */
+  private suspend fun persistSurvivingNode(positionKey: PositionKey) {
     val node = tree[positionKey] ?: return
     database.insertNodes(node.toDataNode())
   }
@@ -257,6 +282,7 @@ private fun Node.toDataNode(): DataNode =
       ),
     cardState = cardState,
     depth = depth,
+    hasGoodOutgoing = outgoing.values.any { it.isGood == true && !it.isDeleted },
     updatedAt = DateUtil.now(),
   )
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/control/TrainingBoardPage.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/control/TrainingBoardPage.kt
@@ -91,7 +91,6 @@ private class TrainingBoard : KoinComponent {
 
   @Composable
   fun Draw(modifier: Modifier = Modifier) {
-    val scope = rememberCoroutineScope()
     val numberOfNodesToTrain by
       produceState(0, localReloader.getKey(), daysInAdvance) {
         value = trainingScheduler.pendingCount(dayOffset(daysInAdvance))

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/control/TrainingBoardPage.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/board/control/TrainingBoardPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.days
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -53,11 +54,17 @@ import proj.memorchess.axl.ui.theme.LocalKineticTypography
 import proj.memorchess.axl.ui.theme.goodTint
 import proj.memorchess.axl.ui.util.BasicReloader
 
-/** Training board entry point. Loads the tree on entry. */
+/** Training board entry point. Loads the tree and selects the first card on entry. */
 @Composable
 fun TrainingBoardPage(modifier: Modifier = Modifier, treeStore: TreeStore = koinInject()) {
-  LoadingWidget({ treeStore.load() }) {
-    val trainingBoard = remember { TrainingBoard() }
+  val trainingBoard = remember { TrainingBoard() }
+  // The initial card selection is suspendable, so it runs inside the loading phase: the board only
+  // renders once the tree is loaded and the first card is chosen, avoiding a transient "nothing to
+  // train" flash before selection completes.
+  LoadingWidget({
+    treeStore.load()
+    trainingBoard.choseNextNode()
+  }) {
     trainingBoard.Draw(modifier = modifier)
   }
 }
@@ -82,15 +89,12 @@ private class TrainingBoard : KoinComponent {
   private var successCount by mutableStateOf(0)
   private var failCount by mutableStateOf(0)
 
-  init {
-    choseNextNode()
-  }
-
   @Composable
   fun Draw(modifier: Modifier = Modifier) {
-    val numberOfNodesToTrain =
-      remember(localReloader.getKey(), daysInAdvance) {
-        trainingScheduler.pendingCount(dayOffset(daysInAdvance))
+    val scope = rememberCoroutineScope()
+    val numberOfNodesToTrain by
+      produceState(0, localReloader.getKey(), daysInAdvance) {
+        value = trainingScheduler.pendingCount(dayOffset(daysInAdvance))
       }
     // Count each attempt exactly once: increment on the transition into a SHOW_* state. Using
     // LaunchedEffect(state) means we react only when `state` actually changes value, and the
@@ -123,7 +127,12 @@ private class TrainingBoard : KoinComponent {
     }
   }
 
-  private fun choseNextNode() {
+  /**
+   * Selects the next card to train and updates [chosenNode]. Suspends because it queries the
+   * bounded scheduling surface. Called for the initial selection during the loading phase and after
+   * every move or skip.
+   */
+  suspend fun choseNextNode() {
     state = state.toPlayableState()
     localReloader.reload()
     trainerReloader.reload()
@@ -154,6 +163,7 @@ private class TrainingBoard : KoinComponent {
     }
     val palette = LocalKineticPalette.current
     val typography = LocalKineticTypography.current
+    val scope = rememberCoroutineScope()
     Box(
       modifier = modifier.fillMaxSize().background(palette.bg),
       contentAlignment = Alignment.Center,
@@ -183,7 +193,7 @@ private class TrainingBoard : KoinComponent {
         KineticButton(
           onClick = {
             daysInAdvance++
-            choseNextNode()
+            scope.launch { choseNextNode() }
           },
           style = KineticButtonStyle.Primary,
         ) {
@@ -205,6 +215,7 @@ private class TrainingBoard : KoinComponent {
     modifier: Modifier = Modifier,
   ) {
     val cornerTag = stringResource(Res.string.training_corner_tag)
+    val scope = rememberCoroutineScope()
     val trainer = remember {
       val trainer =
         SingleMoveTrainer(nodeToLearn) {
@@ -276,7 +287,7 @@ private class TrainingBoard : KoinComponent {
           controlBar = { mod ->
             TrainingCtrlBar(
               playerTurn = playerTurn,
-              onSkip = { choseNextNode() },
+              onSkip = { scope.launch { choseNextNode() } },
               onHint = {}, // stub for v1
               onReveal = {}, // stub for v1
               modifier = mod,

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestDataNode.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestDataNode.kt
@@ -1,0 +1,19 @@
+package proj.memorchess.axl.core.data
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.time.Instant
+import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.scheduling.CardStateFactory
+
+/** Tests for [DataNode], focused on its derived-column equality semantics. */
+class TestDataNode {
+
+  @Test
+  fun derivedColumnsAreExcludedFromEquality() {
+    val base = DataNode(PositionKey.START_POSITION, PreviousAndNextMoves(), CardStateFactory.new())
+    val withDerived = base.copy(hasGoodOutgoing = true, createdAt = Instant.fromEpochSeconds(123))
+    withDerived shouldBe base
+    withDerived.hashCode() shouldBe base.hashCode()
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.test.runTest
 import proj.memorchess.axl.core.engine.GameEngine
 import proj.memorchess.axl.core.graph.DeleteMode
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.scheduling.CardPhase
+import proj.memorchess.axl.core.scheduling.CardState
 import proj.memorchess.axl.core.scheduling.CardStateFactory
 
 /**
@@ -183,5 +185,217 @@ class TestInMemoryDatabaseQueryManager {
     val nodeStamp = Instant.fromEpochSeconds(900)
     database.insertNodes(node(key0, previous = listOf(), next = listOf(), updatedAt = nodeStamp))
     assertEquals(nodeStamp, database.getLastUpdate())
+  }
+
+  // --- Bounded scheduling query surface ---
+
+  private val now = Instant.fromEpochSeconds(1_000)
+  private val dayStart = Instant.fromEpochSeconds(0)
+  private val dayEnd = Instant.fromEpochSeconds(10_000)
+
+  /** Builds a scheduling node with explicit projection columns and an isolated synthetic key. */
+  private fun schedNode(
+    keyName: String,
+    phase: CardPhase,
+    dueDate: Instant,
+    hasGoodOutgoing: Boolean = true,
+    depth: Int = 0,
+    createdAt: Instant = Instant.fromEpochSeconds(0),
+    lastReview: Instant? = null,
+    firstReview: Instant? = null,
+    isDeleted: Boolean = false,
+  ): DataNode =
+    DataNode(
+      positionKey = PositionKey(keyName),
+      previousAndNextMoves = PreviousAndNextMoves(),
+      cardState =
+        CardState(
+          dueDate = dueDate,
+          lastReview = lastReview,
+          firstReview = firstReview,
+          stability = 0.0,
+          difficulty = 0.0,
+          reps = 0,
+          lapses = 0,
+          phase = phase,
+          step = 0,
+        ),
+      depth = depth,
+      isDeleted = isDeleted,
+      hasGoodOutgoing = hasGoodOutgoing,
+      createdAt = createdAt,
+    )
+
+  @Test
+  fun nextDueReviewCard_picksSmallestDepthAmongDueGoodReviews() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      schedNode("deep", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(100), depth = 5),
+      schedNode("shallow", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(200), depth = 1),
+      // Not good: excluded even though shallowest and due.
+      schedNode(
+        "notgood",
+        CardPhase.REVIEW,
+        dueDate = Instant.fromEpochSeconds(50),
+        depth = 0,
+        hasGoodOutgoing = false,
+      ),
+      // Wrong phase.
+      schedNode("new", CardPhase.NEW, dueDate = Instant.fromEpochSeconds(50), depth = 0),
+    )
+    assertEquals(PositionKey("shallow"), database.nextDueReviewCard(dayEnd)?.positionKey)
+  }
+
+  @Test
+  fun nextDueReviewCard_excludesDueDateEqualToDayEnd() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    // dueDate exactly at the exclusive bound belongs to the next day.
+    database.insertNodes(schedNode("boundary", CardPhase.REVIEW, dueDate = dayEnd, depth = 0))
+    assertNull(database.nextDueReviewCard(dayEnd))
+  }
+
+  @Test
+  fun nextDueNewCard_ordersByDepthThenCreatedAt() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      schedNode(
+        "d1late",
+        CardPhase.NEW,
+        dueDate = Instant.fromEpochSeconds(100),
+        depth = 1,
+        createdAt = Instant.fromEpochSeconds(500),
+      ),
+      schedNode(
+        "d1early",
+        CardPhase.NEW,
+        dueDate = Instant.fromEpochSeconds(100),
+        depth = 1,
+        createdAt = Instant.fromEpochSeconds(300),
+      ),
+      schedNode(
+        "d0",
+        CardPhase.NEW,
+        dueDate = Instant.fromEpochSeconds(100),
+        depth = 0,
+        createdAt = Instant.fromEpochSeconds(900),
+      ),
+    )
+    // Shallowest wins regardless of createdAt.
+    assertEquals(PositionKey("d0"), database.nextDueNewCard(dayEnd)?.positionKey)
+    // Among the depth-1 ties, the earlier createdAt wins once d0 is removed.
+    database.deletePosition(PositionKey("d0"), DeleteMode.HARD)
+    assertEquals(PositionKey("d1early"), database.nextDueNewCard(dayEnd)?.positionKey)
+  }
+
+  @Test
+  fun nextReadyLearningCard_includesDueEqualToNow() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(schedNode("atNow", CardPhase.LEARNING, dueDate = now))
+    assertEquals(PositionKey("atNow"), database.nextReadyLearningCard(now)?.positionKey)
+  }
+
+  @Test
+  fun nextReadyLearningCard_picksEarliestDueAndCoversRelearning() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      schedNode("late", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(900)),
+      schedNode("early", CardPhase.RELEARNING, dueDate = Instant.fromEpochSeconds(100)),
+      // Pending (due in the future) must not be picked as ready.
+      schedNode("future", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(5_000)),
+    )
+    assertEquals(PositionKey("early"), database.nextReadyLearningCard(now)?.positionKey)
+  }
+
+  @Test
+  fun nextPendingLearningCard_excludesDueEqualToNow() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      schedNode("atNow", CardPhase.LEARNING, dueDate = now),
+      schedNode("future", CardPhase.RELEARNING, dueDate = Instant.fromEpochSeconds(2_000)),
+    )
+    // Strictly greater than now: the card due exactly at now is ready, not pending.
+    assertEquals(PositionKey("future"), database.nextPendingLearningCard(now)?.positionKey)
+  }
+
+  @Test
+  fun nextPendingLearningCard_isNullWhenAllReady() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(schedNode("ready", CardPhase.LEARNING, dueDate = now))
+    assertNull(database.nextPendingLearningCard(now))
+  }
+
+  @Test
+  fun getSchedulingCounts_countsAreDayBounded() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val inWindow = Instant.fromEpochSeconds(5_000)
+    database.insertNodes(
+      // introducedToday: firstReview in window; also trained today.
+      schedNode(
+        "introduced",
+        CardPhase.REVIEW,
+        dueDate = Instant.fromEpochSeconds(100),
+        firstReview = inWindow,
+        lastReview = inWindow,
+        depth = 0,
+      ),
+      // trainedToday only: lastReview in window, firstReview before window.
+      schedNode(
+        "trainedOnly",
+        CardPhase.REVIEW,
+        dueDate = Instant.fromEpochSeconds(200),
+        firstReview = Instant.fromEpochSeconds(-100),
+        lastReview = inWindow,
+        depth = 1,
+      ),
+      // firstReview at the exclusive upper bound: outside the window.
+      schedNode(
+        "atBoundary",
+        CardPhase.REVIEW,
+        dueDate = Instant.fromEpochSeconds(300),
+        firstReview = dayEnd,
+        lastReview = dayEnd,
+        depth = 2,
+      ),
+      // due new, good.
+      schedNode("dueNew", CardPhase.NEW, dueDate = Instant.fromEpochSeconds(400), depth = 3),
+      // in session.
+      schedNode("learning", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(500), depth = 4),
+    )
+    val counts = database.getSchedulingCounts(dayStart, dayEnd)
+    assertEquals(1, counts.introducedToday)
+    assertEquals(2, counts.trainedToday)
+    // dueReviews: introduced, trainedOnly, atBoundary all REVIEW and due before dayEnd.
+    assertEquals(3, counts.dueReviews)
+    assertEquals(1, counts.dueNew)
+    assertEquals(1, counts.inSession)
+  }
+
+  @Test
+  fun getSchedulingCounts_emptyStoreIsAllZero() = runTest {
+    val counts = InMemoryDatabaseQueryManager().getSchedulingCounts(dayStart, dayEnd)
+    assertEquals(SchedulingCounts(0, 0, 0, 0, 0), counts)
+  }
+
+  @Test
+  fun findEligibleAmong_returnsFirstEligibleKeyOrNull() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.insertNodes(
+      // Not in the candidate set even though eligible.
+      schedNode("other", CardPhase.LEARNING, dueDate = now),
+      // In set, in session: eligible.
+      schedNode("learning", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(9_999)),
+      // In set, REVIEW due: eligible.
+      schedNode("dueReview", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(100)),
+      // In set but not due and not in session: ineligible.
+      schedNode("notDue", CardPhase.REVIEW, dueDate = dayEnd),
+    )
+    val candidates =
+      listOf(PositionKey("learning"), PositionKey("dueReview"), PositionKey("notDue"))
+    val result = database.findEligibleAmong(candidates, dayEnd)
+    assertEquals(PositionKey("learning"), result?.positionKey)
+    // Empty candidate set yields null.
+    assertNull(database.findEligibleAmong(emptyList(), dayEnd))
+    // None eligible yields null.
+    assertNull(database.findEligibleAmong(listOf(PositionKey("notDue")), dayEnd))
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
@@ -293,15 +293,35 @@ class TestTrainingScheduler {
   }
 
   @Test
-  fun nextAfterServesAnEligibleReachableChildIgnoringCaps() = runTest {
+  fun nextAfterServesAnEligibleReachableChild() = runTest {
+    val (store, scheduler) = newScheduler()
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    store.addMove(from = posA, move = "e5", to = posB, isGood = true, fromDepth = 1)
+    // With budget available, nextAfter returns the first eligible reachable child so the session
+    // stays in the current line.
+    assertEquals(posA, scheduler.nextAfter(startPos)?.positionKey)
+  }
+
+  @Test
+  fun nextAfterRespectsTheNewCap() = runTest {
     val (store, scheduler) = newScheduler(maxNew = 0)
     store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
     store.addMove(from = posA, move = "e5", to = posB, isGood = true, fromDepth = 1)
-    // nextAfter is a best-effort "stay in the current line" lookup: it returns the first eligible
-    // reachable child (trainable and due today) without consuming or honoring the daily caps. The
-    // cap is enforced by nextDue, which the trainer falls back to. So posA surfaces even with the
-    // new-card cap at zero.
-    assertEquals(posA, scheduler.nextAfter(startPos)?.positionKey)
+    // posA is a brand new card. With the new-card cap at zero, staying in the line must not
+    // introduce it: nextAfter honors the cap and returns null for the reachable NEW child.
+    assertNull(scheduler.nextAfter(startPos))
+  }
+
+  @Test
+  fun nextAfterReturnsNullWhenTotalBudgetIsExhausted() = runTest {
+    val (store, scheduler) = newScheduler(maxTotal = 1)
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    store.addMove(from = posA, move = "e5", to = posB, isGood = true, fromDepth = 1)
+    store.addMove(from = posC, move = "Nf3", to = posB, isGood = true, fromDepth = 0)
+    // posC already consumed the single daily slot today, so the total budget is exhausted. Even a
+    // reachable, otherwise-eligible child must not be served.
+    store.updateCardState(posC, reviewedTodayCard())
+    assertNull(scheduler.nextAfter(startPos))
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTrainingScheduler.kt
@@ -36,9 +36,17 @@ class TestTrainingScheduler {
     maxTotal: Int = Int.MAX_VALUE,
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
   ): Pair<TreeStore, TrainingScheduler> {
-    val store = TreeStore(TestDatabases.empty())
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
     val scheduler =
-      TrainingScheduler(store, Fsrs6SchedulingAlgorithm(), timeZone, { maxNew }, { maxTotal })
+      TrainingScheduler(
+        database,
+        store,
+        Fsrs6SchedulingAlgorithm(),
+        timeZone,
+        { maxNew },
+        { maxTotal },
+      )
     return store to scheduler
   }
 
@@ -156,11 +164,11 @@ class TestTrainingScheduler {
   }
 
   @Test
-  fun nextDuePicksNewCardsByIntroductionOrderNotDepth() = runTest {
-    // Older branch: the e4 line with trainable positions at depths 1 and 2. Newer branch: the d4
-    // line with a trainable position at depth 1. Once startPos and posA are no longer due, the
-    // remaining new cards are posB (depth 2, older line) and posC (depth 1, newer line). The
-    // older line continues before the newer branch starts, even though posC is shallower.
+  fun nextDuePicksNewCardsByDepthThenCreatedAt() = runTest {
+    // New-card ordering is the approximate fallback: shallower positions first, ties broken by the
+    // earliest creation. The e4 line is older (smaller createdAt) but reaches posB at depth 2; the
+    // d4 line is newer but reaches posC at depth 1. Once startPos and posA are no longer due, the
+    // shallower posC must surface before the deeper posB, even though its line was added later.
     val t1 = Instant.parse("2026-01-01T00:00:00Z")
     val t2 = Instant.parse("2026-01-02T00:00:00Z")
     val endOfOldLine = PositionKey("endOld w K")
@@ -172,21 +180,26 @@ class TestTrainingScheduler {
     val d5 = dataMove(posC, "d5", endOfNewLine, t2)
     val database = TestDatabases.empty()
     database.insertNodes(
-      dataNode(startPos, 0, emptyList(), listOf(e4, d4)),
-      dataNode(posA, 1, listOf(e4), listOf(e5)),
-      dataNode(posB, 2, listOf(e5), listOf(g3)),
-      dataNode(endOfOldLine, 3, listOf(g3), emptyList()),
-      dataNode(posC, 1, listOf(d4), listOf(d5)),
-      dataNode(endOfNewLine, 2, listOf(d5), emptyList()),
+      dataNode(startPos, 0, emptyList(), listOf(e4, d4), createdAt = t1),
+      dataNode(posA, 1, listOf(e4), listOf(e5), createdAt = t1),
+      dataNode(posB, 2, listOf(e5), listOf(g3), createdAt = t1),
+      dataNode(endOfOldLine, 3, listOf(g3), emptyList(), createdAt = t1, hasGoodOutgoing = false),
+      dataNode(posC, 1, listOf(d4), listOf(d5), createdAt = t2),
+      dataNode(endOfNewLine, 2, listOf(d5), emptyList(), createdAt = t2, hasGoodOutgoing = false),
     )
     val store = TreeStore(database)
     store.load()
     val scheduler =
-      TrainingScheduler(store, Fsrs6SchedulingAlgorithm(), TimeZone.currentSystemDefault())
+      TrainingScheduler(
+        database,
+        store,
+        Fsrs6SchedulingAlgorithm(),
+        TimeZone.currentSystemDefault(),
+      )
     val now = DateUtil.now()
     store.updateCardState(startPos, CardStateFactory.new(now + 5.days))
     store.updateCardState(posA, CardStateFactory.new(now + 5.days))
-    assertEquals(posB, scheduler.nextDue()?.positionKey)
+    assertEquals(posC, scheduler.nextDue()?.positionKey)
   }
 
   // Daily caps: how many new moves and how many total moves are served per day.
@@ -280,10 +293,23 @@ class TestTrainingScheduler {
   }
 
   @Test
-  fun nextAfterRespectsTheCaps() = runTest {
+  fun nextAfterServesAnEligibleReachableChildIgnoringCaps() = runTest {
     val (store, scheduler) = newScheduler(maxNew = 0)
     store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
     store.addMove(from = posA, move = "e5", to = posB, isGood = true, fromDepth = 1)
+    // nextAfter is a best-effort "stay in the current line" lookup: it returns the first eligible
+    // reachable child (trainable and due today) without consuming or honoring the daily caps. The
+    // cap is enforced by nextDue, which the trainer falls back to. So posA surfaces even with the
+    // new-card cap at zero.
+    assertEquals(posA, scheduler.nextAfter(startPos)?.positionKey)
+  }
+
+  @Test
+  fun nextAfterReturnsNullWhenNoReachableChildIsEligible() = runTest {
+    val (store, scheduler) = newScheduler()
+    // startPos's only child posA has no good outgoing edge, so it is not trainable and not
+    // eligible; nextAfter then finds nothing reachable.
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
     assertNull(scheduler.nextAfter(startPos))
   }
 
@@ -319,6 +345,41 @@ class TestTrainingScheduler {
     assertEquals(startPos, scheduler.nextDue(today)?.positionKey)
   }
 
+  @Test
+  fun emptyRepertoireServesNothing() = runTest {
+    val (_, scheduler) = newScheduler()
+    assertNull(scheduler.nextDue())
+    assertEquals(0, scheduler.pendingCount())
+    assertNull(scheduler.nextAfter(startPos))
+  }
+
+  @Test
+  fun reviewDueExactlyAtNextMidnightIsNotServedToday() = runTest {
+    val zone = UtcOffset(hours = 1).asTimeZone()
+    val (store, scheduler) = newScheduler(timeZone = zone)
+    val today = LocalDate(2026, 6, 13)
+    // dueDate sits exactly on the exclusive day boundary (next local midnight). Because the bound
+    // is exclusive, the review belongs to the next day and must not be served for today.
+    val nextMidnight = LocalDateTime(2026, 6, 14, 0, 0).toInstant(zone)
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    store.updateCardState(startPos, reviewCard(nextMidnight))
+    assertNull(scheduler.nextDue(today))
+    assertEquals(0, scheduler.pendingCount(today))
+  }
+
+  @Test
+  fun reviewDueOneSecondBeforeMidnightIsServedToday() = runTest {
+    val zone = UtcOffset(hours = 1).asTimeZone()
+    val (store, scheduler) = newScheduler(timeZone = zone)
+    val today = LocalDate(2026, 6, 13)
+    // One second below the exclusive boundary: still due today.
+    val justBeforeMidnight = LocalDateTime(2026, 6, 13, 23, 59, 59).toInstant(zone)
+    store.addMove(from = startPos, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    store.updateCardState(startPos, reviewCard(justBeforeMidnight))
+    assertEquals(startPos, scheduler.nextDue(today)?.positionKey)
+    assertEquals(1, scheduler.pendingCount(today))
+  }
+
   private fun reviewedTodayCard(): CardState {
     val now = DateUtil.now()
     return CardState(
@@ -349,12 +410,16 @@ class TestTrainingScheduler {
     depth: Int,
     incoming: List<DataMove>,
     outgoing: List<DataMove>,
+    createdAt: Instant = DateUtil.now(),
+    hasGoodOutgoing: Boolean = true,
   ) =
     DataNode(
       positionKey = key,
       previousAndNextMoves = PreviousAndNextMoves(incoming, outgoing),
       cardState = CardStateFactory.new(),
       depth = depth,
+      hasGoodOutgoing = hasGoodOutgoing,
+      createdAt = createdAt,
     )
 
   private fun reviewCard(due: Instant): CardState =

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTreeStore.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTreeStore.kt
@@ -1,23 +1,56 @@
 package proj.memorchess.axl.core.graph
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
+import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.date.DateUtil
+import proj.memorchess.axl.core.scheduling.CardStateFactory
 import proj.memorchess.axl.test_util.TestDatabases
 
 /**
- * Tests for the derived projection column [DataNode.hasGoodOutgoing], maintained by [TreeStore] on
- * every write. Assertions read the persisted [DataNode] back through the public
- * [proj.memorchess.axl.core.data.DatabaseQueryManager.getPosition] API.
+ * Tests for the derived projection columns [DataNode.hasGoodOutgoing] and [DataNode.createdAt],
+ * maintained by [TreeStore] on every write. Assertions read the persisted [DataNode] back through
+ * the public [proj.memorchess.axl.core.data.DatabaseQueryManager.getPosition] API.
  */
 class TestTreeStore {
 
   private val start = PositionKey.START_POSITION
   private val posA = PositionKey("posA b K")
+  private val posB = PositionKey("posB w K")
+  private val posC = PositionKey("posC b K")
+
+  private val t1 = Instant.parse("2026-01-01T00:00:00Z")
+  private val t2 = Instant.parse("2026-01-02T00:00:00Z")
+
+  private fun move(from: PositionKey, san: String, to: PositionKey, createdAt: Instant) =
+    DataMove(
+      origin = from,
+      destination = to,
+      move = san,
+      isGood = true,
+      createdAt = createdAt,
+      updatedAt = createdAt,
+    )
+
+  private fun node(
+    key: PositionKey,
+    depth: Int,
+    incoming: List<DataMove>,
+    outgoing: List<DataMove>,
+  ) =
+    DataNode(
+      positionKey = key,
+      previousAndNextMoves = PreviousAndNextMoves(incoming, outgoing),
+      cardState = CardStateFactory.new(),
+      depth = depth,
+    )
 
   @Test
   fun classifyingFirstGoodEdgeSetsHasGoodOutgoingTrue() = runTest {
@@ -70,6 +103,49 @@ class TestTreeStore {
     assertFalse(
       persisted.hasGoodOutgoing,
       "a bad (isGood == false) edge must not set hasGoodOutgoing",
+    )
+  }
+
+  @Test
+  fun nodeCreatedAtIsEarliestIncomingEdgeCreatedAt() = runTest {
+    // posB has two good incoming edges with distinct createdAt; the persisted createdAt must be the
+    // earlier one. Seed via insertNodes + load so the edge createdAt values are controlled, then a
+    // write to posB re-persists it through Node.toDataNode().
+    val viaA = move(posA, "Nc3", posB, t2)
+    val viaC = move(posC, "Nf3", posB, t1)
+    val database = TestDatabases.empty()
+    database.insertNodes(
+      node(posA, 1, emptyList(), listOf(viaA)),
+      node(posC, 1, emptyList(), listOf(viaC)),
+      node(posB, 2, listOf(viaA, viaC), emptyList()),
+    )
+    val store = TreeStore(database)
+    store.load()
+    // Trigger a re-persist of posB by adding an outgoing edge from it.
+    store.addMove(from = posB, move = "d4", to = start, isGood = true, fromDepth = 2)
+    val persisted = database.getPosition(posB)
+    assertNotNull(persisted)
+    assertEquals(
+      t1,
+      persisted.createdAt,
+      "createdAt must be the earliest non deleted incoming edge createdAt",
+    )
+  }
+
+  @Test
+  fun rootNodeCreatedAtFallsBackToNow() = runTest {
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
+    // The start position is persisted as the origin of a classified edge; it has no incoming edges,
+    // so createdAt falls back to now and is a set, non throwing value within the call window.
+    val before = DateUtil.now()
+    store.addMove(from = start, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    val after = DateUtil.now()
+    val persisted = database.getPosition(start)
+    assertNotNull(persisted)
+    assertTrue(
+      persisted.createdAt >= before && persisted.createdAt <= after,
+      "root createdAt must fall back to ~now when there are no incoming edges",
     )
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTreeStore.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestTreeStore.kt
@@ -1,0 +1,75 @@
+package proj.memorchess.axl.core.graph
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.test_util.TestDatabases
+
+/**
+ * Tests for the derived projection column [DataNode.hasGoodOutgoing], maintained by [TreeStore] on
+ * every write. Assertions read the persisted [DataNode] back through the public
+ * [proj.memorchess.axl.core.data.DatabaseQueryManager.getPosition] API.
+ */
+class TestTreeStore {
+
+  private val start = PositionKey.START_POSITION
+  private val posA = PositionKey("posA b K")
+
+  @Test
+  fun classifyingFirstGoodEdgeSetsHasGoodOutgoingTrue() = runTest {
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
+    store.addMove(from = start, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    val persisted = database.getPosition(start)
+    assertNotNull(persisted)
+    assertTrue(persisted.hasGoodOutgoing, "a classified good edge must set hasGoodOutgoing")
+  }
+
+  @Test
+  fun deletingLastGoodEdgeSetsHasGoodOutgoingFalse() = runTest {
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
+    store.addMove(from = start, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    assertTrue(database.getPosition(start)!!.hasGoodOutgoing)
+    store.deleteMove(from = start, move = "e4")
+    val afterDelete = database.getPosition(start)
+    assertNotNull(afterDelete)
+    assertFalse(
+      afterDelete.hasGoodOutgoing,
+      "deleting the last good edge must flip hasGoodOutgoing back to false",
+    )
+  }
+
+  @Test
+  fun deletingNodeRePersistsSurvivingOrigin() = runTest {
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
+    store.addMove(from = start, move = "e4", to = posA, isGood = true, fromDepth = 0)
+    assertTrue(database.getPosition(start)!!.hasGoodOutgoing)
+    store.deleteNode(posA)
+    val origin = database.getPosition(start)
+    assertNotNull(origin)
+    assertFalse(
+      origin.hasGoodOutgoing,
+      "deleting the only good destination must flip the origin's hasGoodOutgoing to false",
+    )
+  }
+
+  @Test
+  fun explorationEdgeDoesNotSetHasGoodOutgoing() = runTest {
+    val database = TestDatabases.empty()
+    val store = TreeStore(database)
+    // An exploration edge (isGood == null) is not persisted, then classify it as a known mistake.
+    store.addMove(from = start, move = "e4", to = posA, isGood = false, fromDepth = 0)
+    val persisted = database.getPosition(start)
+    assertNotNull(persisted)
+    assertFalse(
+      persisted.hasGoodOutgoing,
+      "a bad (isGood == false) edge must not set hasGoodOutgoing",
+    )
+  }
+}

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabases.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabases.kt
@@ -49,6 +49,7 @@ object TestDatabases {
           PreviousAndNextMoves(previousMove?.let { listOf(it) } ?: listOf(), listOf(dataMove)),
           CardStateFactory.new(),
           depth,
+          hasGoodOutgoing = true,
         )
       previousMove = dataMove
       nodes.add(node)
@@ -80,6 +81,7 @@ object TestDatabases {
               storedNode.positionKey,
               PreviousAndNextMoves(previousMoves, newMoves),
               CardStateFactory.new(),
+              hasGoodOutgoing = newMoves.any { it.isGood == true && !it.isDeleted },
             )
         }
       }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
@@ -71,9 +71,15 @@ class TestTraining : TestWithKoin() {
     val e4Pos = engine.toPositionKey()
     val e4Move = DataMove(startPos, e4Pos, "e4", isGood = true)
 
-    // Create the node with the move
+    // Create the node with the move. The good outgoing e4 edge makes it trainable, so the derived
+    // hasGoodOutgoing projection the scheduler filters on must be set.
     val testNode =
-      DataNode(positionKey = startPos, PreviousAndNextMoves(listOf(), listOf(e4Move)), cardState)
+      DataNode(
+        positionKey = startPos,
+        PreviousAndNextMoves(listOf(), listOf(e4Move)),
+        cardState,
+        hasGoodOutgoing = true,
+      )
 
     // Save the node to the database
     database.insertNodes(testNode)
@@ -205,6 +211,8 @@ class TestTraining : TestWithKoin() {
           positionKey = e4Pos,
           PreviousAndNextMoves(listOf(e4Move), listOf(e5Move)),
           dueNowFromLastWeek(),
+          depth = 1,
+          hasGoodOutgoing = true,
         )
       resetDatabase()
       database.insertNodes(testNode)
@@ -244,6 +252,7 @@ class TestTraining : TestWithKoin() {
           positionKey = startPosition,
           PreviousAndNextMoves(listOf(), listOf(startMove)),
           dueNowFromLastWeek(),
+          hasGoodOutgoing = true,
         )
       database.eraseAll()
       database.insertNodes(node)

--- a/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestRoomSchedulingQueries.kt
+++ b/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestRoomSchedulingQueries.kt
@@ -1,0 +1,207 @@
+package proj.memorchess.axl.core.data
+
+import androidx.room.Room
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.scheduling.CardPhase
+import proj.memorchess.axl.core.scheduling.CardState
+
+/**
+ * Room backed coverage of the bounded scheduling query surface. Mirrors the predicate, ordering and
+ * boundary cases of the in-memory reference against a real isolated SQLite database, proving the
+ * `WHERE` / `ORDER BY` / `LIMIT` / `COUNT` clauses and the projection to
+ * [proj.memorchess.axl.core.graph.TrainingEntry] match the reference semantics.
+ */
+class TestRoomSchedulingQueries {
+
+  private val database: CustomDatabase = freshDatabase()
+  private val manager: DatabaseQueryManager = NonJsLocalDatabaseQueryManager(database)
+
+  private val now = Instant.fromEpochSeconds(1_000)
+  private val dayStart = Instant.fromEpochSeconds(0)
+  private val dayEnd = Instant.fromEpochSeconds(10_000)
+
+  private fun freshDatabase(): CustomDatabase {
+    val dbFile = File(System.getProperty("java.io.tmpdir"), "room_sched_${UUID.randomUUID()}.db")
+    return getRoomDatabase(Room.databaseBuilder<CustomDatabase>(name = dbFile.absolutePath))
+  }
+
+  @AfterTest
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun insert(
+    keyName: String,
+    phase: CardPhase,
+    dueDate: Instant,
+    hasGoodOutgoing: Boolean = true,
+    depth: Int = 0,
+    createdAt: Instant = Instant.fromEpochSeconds(0),
+    lastReview: Instant? = null,
+    firstReview: Instant? = null,
+    isDeleted: Boolean = false,
+  ) {
+    manager.insertNodes(
+      DataNode(
+        positionKey = PositionKey(keyName),
+        previousAndNextMoves = PreviousAndNextMoves(),
+        cardState =
+          CardState(
+            dueDate = dueDate,
+            lastReview = lastReview,
+            firstReview = firstReview,
+            stability = 0.0,
+            difficulty = 0.0,
+            reps = 0,
+            lapses = 0,
+            phase = phase,
+            step = 0,
+          ),
+        depth = depth,
+        isDeleted = isDeleted,
+        hasGoodOutgoing = hasGoodOutgoing,
+        createdAt = createdAt,
+      )
+    )
+  }
+
+  @Test
+  fun nextDueReviewCard_picksSmallestDepthAmongDueGoodReviews() = runTest {
+    insert("deep", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(100), depth = 5)
+    insert("shallow", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(200), depth = 1)
+    insert(
+      "notgood",
+      CardPhase.REVIEW,
+      dueDate = Instant.fromEpochSeconds(50),
+      depth = 0,
+      hasGoodOutgoing = false,
+    )
+    insert("new", CardPhase.NEW, dueDate = Instant.fromEpochSeconds(50), depth = 0)
+    manager.nextDueReviewCard(dayEnd)?.positionKey shouldBe PositionKey("shallow")
+  }
+
+  @Test
+  fun nextDueReviewCard_excludesDueDateEqualToDayEnd() = runTest {
+    insert("boundary", CardPhase.REVIEW, dueDate = dayEnd, depth = 0)
+    manager.nextDueReviewCard(dayEnd) shouldBe null
+  }
+
+  @Test
+  fun nextDueNewCard_ordersByDepthThenCreatedAt() = runTest {
+    insert(
+      "d1late",
+      CardPhase.NEW,
+      dueDate = Instant.fromEpochSeconds(100),
+      depth = 1,
+      createdAt = Instant.fromEpochSeconds(500),
+    )
+    insert(
+      "d1early",
+      CardPhase.NEW,
+      dueDate = Instant.fromEpochSeconds(100),
+      depth = 1,
+      createdAt = Instant.fromEpochSeconds(300),
+    )
+    insert(
+      "d0",
+      CardPhase.NEW,
+      dueDate = Instant.fromEpochSeconds(100),
+      depth = 0,
+      createdAt = Instant.fromEpochSeconds(900),
+    )
+    manager.nextDueNewCard(dayEnd)?.positionKey shouldBe PositionKey("d0")
+    manager.deletePosition(PositionKey("d0"), proj.memorchess.axl.core.graph.DeleteMode.HARD)
+    manager.nextDueNewCard(dayEnd)?.positionKey shouldBe PositionKey("d1early")
+  }
+
+  @Test
+  fun nextReadyLearningCard_includesDueEqualToNow() = runTest {
+    insert("atNow", CardPhase.LEARNING, dueDate = now)
+    manager.nextReadyLearningCard(now)?.positionKey shouldBe PositionKey("atNow")
+  }
+
+  @Test
+  fun nextReadyLearningCard_picksEarliestDueAndCoversRelearning() = runTest {
+    insert("late", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(900))
+    insert("early", CardPhase.RELEARNING, dueDate = Instant.fromEpochSeconds(100))
+    insert("future", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(5_000))
+    manager.nextReadyLearningCard(now)?.positionKey shouldBe PositionKey("early")
+  }
+
+  @Test
+  fun nextPendingLearningCard_excludesDueEqualToNow() = runTest {
+    insert("atNow", CardPhase.LEARNING, dueDate = now)
+    insert("future", CardPhase.RELEARNING, dueDate = Instant.fromEpochSeconds(2_000))
+    manager.nextPendingLearningCard(now)?.positionKey shouldBe PositionKey("future")
+  }
+
+  @Test
+  fun nextPendingLearningCard_isNullWhenAllReady() = runTest {
+    insert("ready", CardPhase.LEARNING, dueDate = now)
+    manager.nextPendingLearningCard(now) shouldBe null
+  }
+
+  @Test
+  fun getSchedulingCounts_countsAreDayBounded() = runTest {
+    val inWindow = Instant.fromEpochSeconds(5_000)
+    insert(
+      "introduced",
+      CardPhase.REVIEW,
+      dueDate = Instant.fromEpochSeconds(100),
+      firstReview = inWindow,
+      lastReview = inWindow,
+      depth = 0,
+    )
+    insert(
+      "trainedOnly",
+      CardPhase.REVIEW,
+      dueDate = Instant.fromEpochSeconds(200),
+      firstReview = Instant.fromEpochSeconds(-100),
+      lastReview = inWindow,
+      depth = 1,
+    )
+    insert(
+      "atBoundary",
+      CardPhase.REVIEW,
+      dueDate = Instant.fromEpochSeconds(300),
+      firstReview = dayEnd,
+      lastReview = dayEnd,
+      depth = 2,
+    )
+    insert("dueNew", CardPhase.NEW, dueDate = Instant.fromEpochSeconds(400), depth = 3)
+    insert("learning", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(500), depth = 4)
+    manager.getSchedulingCounts(dayStart, dayEnd) shouldBe
+      SchedulingCounts(
+        introducedToday = 1,
+        trainedToday = 2,
+        dueReviews = 3,
+        dueNew = 1,
+        inSession = 1,
+      )
+  }
+
+  @Test
+  fun getSchedulingCounts_emptyStoreIsAllZero() = runTest {
+    manager.getSchedulingCounts(dayStart, dayEnd) shouldBe SchedulingCounts(0, 0, 0, 0, 0)
+  }
+
+  @Test
+  fun findEligibleAmong_returnsFirstEligibleKeyOrNull() = runTest {
+    insert("other", CardPhase.LEARNING, dueDate = now)
+    insert("learning", CardPhase.LEARNING, dueDate = Instant.fromEpochSeconds(9_999))
+    insert("dueReview", CardPhase.REVIEW, dueDate = Instant.fromEpochSeconds(100))
+    insert("notDue", CardPhase.REVIEW, dueDate = dayEnd)
+    val candidates =
+      listOf(PositionKey("learning"), PositionKey("dueReview"), PositionKey("notDue"))
+    manager.findEligibleAmong(candidates, dayEnd)?.positionKey shouldBe PositionKey("learning")
+    manager.findEligibleAmong(emptyList(), dayEnd) shouldBe null
+    manager.findEligibleAmong(listOf(PositionKey("notDue")), dayEnd) shouldBe null
+  }
+}

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/CustomDatabase.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/CustomDatabase.kt
@@ -13,7 +13,7 @@ import proj.memorchess.axl.core.data.explorer.ExplorerCacheEntity
 
 @Database(
   entities = [NodeEntity::class, MoveEntity::class, ExplorerCacheEntity::class],
-  version = 7,
+  version = 8,
   exportSchema = false,
 )
 @TypeConverters(DateConverters::class)

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeCardProjection.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeCardProjection.kt
@@ -1,0 +1,32 @@
+package proj.memorchess.axl.core.data
+
+import kotlin.time.Instant
+
+/**
+ * Lightweight Room projection holding only the columns a
+ * [proj.memorchess.axl.core.graph.TrainingEntry] needs. It never loads edges, keeping the bounded
+ * scheduling queries cheap.
+ *
+ * @property positionKey FEN string identifying the position.
+ * @property dueDate Moment the card is next due.
+ * @property lastReview Moment of the most recent review, or `null` for a brand new card.
+ * @property firstReview Moment of the very first review, or `null` for a never reviewed card.
+ * @property stability FSRS stability of the memory trace, in days.
+ * @property difficulty FSRS card difficulty.
+ * @property reps Total number of recorded reviews.
+ * @property lapses Total number of times the card has been forgotten.
+ * @property phase Name of the [proj.memorchess.axl.core.scheduling.CardPhase].
+ * @property step Index into the active learning or relearning step ladder.
+ */
+data class NodeCardProjection(
+  val positionKey: String,
+  val dueDate: Instant,
+  val lastReview: Instant?,
+  val firstReview: Instant?,
+  val stability: Double,
+  val difficulty: Double,
+  val reps: Int,
+  val lapses: Int,
+  val phase: String,
+  val step: Int,
+)

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntity.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntity.kt
@@ -26,6 +26,11 @@ import proj.memorchess.axl.core.scheduling.CardPhase
  *   machine.
  * @property step Index into the active learning or relearning step ladder.
  * @property depth Minimum graph depth at which this position can be reached from the root.
+ * @property hasGoodOutgoing Derived projection owned by [proj.memorchess.axl.core.graph.TreeStore]:
+ *   `true` iff this node has at least one non deleted outgoing edge marked good. Backs the bounded
+ *   scheduling queries.
+ * @property createdAt Derived projection owned by [proj.memorchess.axl.core.graph.TreeStore]: the
+ *   moment the position was first added, used as the new card ordering tiebreak after [depth].
  * @property isDeleted Soft delete flag.
  * @property updatedAt Last modification timestamp.
  */
@@ -33,10 +38,12 @@ import proj.memorchess.axl.core.scheduling.CardPhase
   tableName = "NodeEntity",
   indices =
     [
-      Index(value = ["dueDate"]),
-      Index(value = ["depth"]),
       Index(value = ["isDeleted"]),
       Index(value = ["updatedAt"]),
+      Index(value = ["firstReview"]),
+      Index(value = ["lastReview"]),
+      Index(value = ["hasGoodOutgoing", "phase", "dueDate", "depth", "createdAt"]),
+      Index(value = ["hasGoodOutgoing", "phase", "dueDate"]),
     ],
 )
 data class NodeEntity(
@@ -51,6 +58,8 @@ data class NodeEntity(
   val phase: String = CardPhase.NEW.name,
   val step: Int = 0,
   val depth: Int,
+  val hasGoodOutgoing: Boolean = false,
+  val createdAt: Instant = DateUtil.now(),
   val isDeleted: Boolean = false,
   val updatedAt: Instant = DateUtil.now(),
 )

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
@@ -118,4 +118,109 @@ interface NodeEntityDao {
   @Query("SELECT MAX(updatedAt) FROM NodeEntity") suspend fun getLastNodeUpdate(): Instant?
 
   @Query("SELECT MAX(updatedAt) FROM MoveEntity") suspend fun getLastMoveUpdate(): Instant?
+
+  /**
+   * Next ready in session card: mid learning and due on or before [now], earliest due first. See
+   * [DatabaseQueryManager.nextReadyLearningCard].
+   */
+  @Query(
+    "SELECT positionKey, dueDate, lastReview, firstReview, stability, difficulty, reps, lapses, phase, step " +
+      "FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 " +
+      "AND phase IN ('LEARNING', 'RELEARNING') AND dueDate <= :now ORDER BY dueDate ASC LIMIT 1"
+  )
+  suspend fun nextReadyLearningCard(now: Instant): NodeCardProjection?
+
+  /**
+   * Next pending in session card: mid learning and due strictly after [now], earliest due first.
+   * See [DatabaseQueryManager.nextPendingLearningCard].
+   */
+  @Query(
+    "SELECT positionKey, dueDate, lastReview, firstReview, stability, difficulty, reps, lapses, phase, step " +
+      "FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 " +
+      "AND phase IN ('LEARNING', 'RELEARNING') AND dueDate > :now ORDER BY dueDate ASC LIMIT 1"
+  )
+  suspend fun nextPendingLearningCard(now: Instant): NodeCardProjection?
+
+  /**
+   * Next due review card: graduated and due before [dayEndExclusive], shallowest first. See
+   * [DatabaseQueryManager.nextDueReviewCard].
+   */
+  @Query(
+    "SELECT positionKey, dueDate, lastReview, firstReview, stability, difficulty, reps, lapses, phase, step " +
+      "FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 AND phase = 'REVIEW' " +
+      "AND dueDate < :dayEndExclusive ORDER BY depth ASC LIMIT 1"
+  )
+  suspend fun nextDueReviewCard(dayEndExclusive: Instant): NodeCardProjection?
+
+  /**
+   * Next due new card: brand new and due before [dayEndExclusive], shallowest then earliest created
+   * first. See [DatabaseQueryManager.nextDueNewCard].
+   */
+  @Query(
+    "SELECT positionKey, dueDate, lastReview, firstReview, stability, difficulty, reps, lapses, phase, step " +
+      "FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 AND phase = 'NEW' " +
+      "AND dueDate < :dayEndExclusive ORDER BY depth ASC, createdAt ASC LIMIT 1"
+  )
+  suspend fun nextDueNewCard(dayEndExclusive: Instant): NodeCardProjection?
+
+  /** Count of cards first reviewed within the day window. */
+  @Query(
+    "SELECT COUNT(*) FROM NodeEntity WHERE isDeleted = 0 " +
+      "AND firstReview >= :dayStart AND firstReview < :dayEndExclusive"
+  )
+  suspend fun countIntroducedBetween(dayStart: Instant, dayEndExclusive: Instant): Int
+
+  /** Count of cards last reviewed within the day window. */
+  @Query(
+    "SELECT COUNT(*) FROM NodeEntity WHERE isDeleted = 0 " +
+      "AND lastReview >= :dayStart AND lastReview < :dayEndExclusive"
+  )
+  suspend fun countTrainedBetween(dayStart: Instant, dayEndExclusive: Instant): Int
+
+  /** Count of trainable graduated cards due before [dayEndExclusive]. */
+  @Query(
+    "SELECT COUNT(*) FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 " +
+      "AND phase = 'REVIEW' AND dueDate < :dayEndExclusive"
+  )
+  suspend fun countDueReviews(dayEndExclusive: Instant): Int
+
+  /** Count of trainable brand new cards due before [dayEndExclusive]. */
+  @Query(
+    "SELECT COUNT(*) FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 " +
+      "AND phase = 'NEW' AND dueDate < :dayEndExclusive"
+  )
+  suspend fun countDueNew(dayEndExclusive: Instant): Int
+
+  /** Count of trainable cards currently mid learning. */
+  @Query(
+    "SELECT COUNT(*) FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 " +
+      "AND phase IN ('LEARNING', 'RELEARNING')"
+  )
+  suspend fun countInSession(): Int
+
+  /**
+   * Computes the day's five scheduling tallies in one transaction. See
+   * [DatabaseQueryManager.getSchedulingCounts].
+   */
+  @Transaction
+  suspend fun getSchedulingCounts(dayStart: Instant, dayEndExclusive: Instant): SchedulingCounts =
+    SchedulingCounts(
+      introducedToday = countIntroducedBetween(dayStart, dayEndExclusive),
+      trainedToday = countTrainedBetween(dayStart, dayEndExclusive),
+      dueReviews = countDueReviews(dayEndExclusive),
+      dueNew = countDueNew(dayEndExclusive),
+      inSession = countInSession(),
+    )
+
+  /**
+   * Eligible projections among an explicit bounded key set: trainable and either mid learning or
+   * due before [dayEndExclusive]. The caller orders the result by candidate order. See
+   * [DatabaseQueryManager.findEligibleAmong].
+   */
+  @Query(
+    "SELECT positionKey, dueDate, lastReview, firstReview, stability, difficulty, reps, lapses, phase, step " +
+      "FROM NodeEntity WHERE isDeleted = 0 AND hasGoodOutgoing = 1 AND positionKey IN (:keys) " +
+      "AND (phase IN ('LEARNING', 'RELEARNING') OR dueDate < :dayEndExclusive)"
+  )
+  suspend fun eligibleAmong(keys: List<String>, dayEndExclusive: Instant): List<NodeCardProjection>
 }

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeWithMoves.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeWithMoves.kt
@@ -34,6 +34,8 @@ data class NodeWithMoves(
       node.depth,
       node.updatedAt,
       node.isDeleted,
+      node.hasGoodOutgoing,
+      node.createdAt,
     )
   }
 
@@ -53,6 +55,8 @@ data class NodeWithMoves(
           phase = card.phase.name,
           step = card.step,
           depth = dataNode.depth,
+          hasGoodOutgoing = dataNode.hasGoodOutgoing,
+          createdAt = dataNode.createdAt,
           isDeleted = dataNode.isDeleted,
           updatedAt = dataNode.updatedAt,
         ),

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
@@ -3,11 +3,18 @@ package proj.memorchess.axl.core.data
 import kotlin.time.Instant
 import proj.memorchess.axl.core.date.DateUtil.truncateToSeconds
 import proj.memorchess.axl.core.graph.DeleteMode
+import proj.memorchess.axl.core.graph.TrainingEntry
+import proj.memorchess.axl.core.scheduling.CardPhase
+import proj.memorchess.axl.core.scheduling.CardState
 
-/** Database for non-JS platforms */
-internal object NonJsLocalDatabaseQueryManager : DatabaseQueryManager {
-
-  private val database = customDatabase
+/**
+ * Room backed [DatabaseQueryManager] for non-JS platforms.
+ *
+ * Takes its [CustomDatabase] explicitly so the production singleton wires the shared file while
+ * tests can drive an isolated database through the same public API.
+ */
+internal class NonJsLocalDatabaseQueryManager(private val database: CustomDatabase) :
+  DatabaseQueryManager {
 
   override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> {
     val allNodes = database.getNodeEntityDao().getAllNodes()
@@ -66,8 +73,56 @@ internal object NonJsLocalDatabaseQueryManager : DatabaseQueryManager {
       })
       ?.truncateToSeconds()
   }
+
+  override suspend fun nextReadyLearningCard(now: Instant): TrainingEntry? =
+    database.getNodeEntityDao().nextReadyLearningCard(now)?.toTrainingEntry()
+
+  override suspend fun nextPendingLearningCard(now: Instant): TrainingEntry? =
+    database.getNodeEntityDao().nextPendingLearningCard(now)?.toTrainingEntry()
+
+  override suspend fun nextDueReviewCard(dayEndExclusive: Instant): TrainingEntry? =
+    database.getNodeEntityDao().nextDueReviewCard(dayEndExclusive)?.toTrainingEntry()
+
+  override suspend fun nextDueNewCard(dayEndExclusive: Instant): TrainingEntry? =
+    database.getNodeEntityDao().nextDueNewCard(dayEndExclusive)?.toTrainingEntry()
+
+  override suspend fun getSchedulingCounts(
+    dayStart: Instant,
+    dayEndExclusive: Instant,
+  ): SchedulingCounts = database.getNodeEntityDao().getSchedulingCounts(dayStart, dayEndExclusive)
+
+  override suspend fun findEligibleAmong(
+    keys: List<PositionKey>,
+    dayEndExclusive: Instant,
+  ): TrainingEntry? {
+    if (keys.isEmpty()) return null
+    val eligible =
+      database
+        .getNodeEntityDao()
+        .eligibleAmong(keys.map { it.value }, dayEndExclusive)
+        .associateBy { it.positionKey }
+    // Preserve the caller's candidate order: return the first key that came back eligible.
+    return keys.firstNotNullOfOrNull { eligible[it.value] }?.toTrainingEntry()
+  }
+
+  /** Rebuilds a [TrainingEntry] from the lightweight projection, no edges loaded. */
+  private fun NodeCardProjection.toTrainingEntry(): TrainingEntry =
+    TrainingEntry(
+      PositionKey(positionKey),
+      CardState(
+        dueDate = dueDate,
+        lastReview = lastReview,
+        firstReview = firstReview,
+        stability = stability,
+        difficulty = difficulty,
+        reps = reps,
+        lapses = lapses,
+        phase = runCatching { CardPhase.valueOf(phase) }.getOrDefault(CardPhase.NEW),
+        step = step,
+      ),
+    )
 }
 
 actual fun getPlatformSpecificLocalDatabase(): DatabaseQueryManager {
-  return NonJsLocalDatabaseQueryManager
+  return NonJsLocalDatabaseQueryManager(customDatabase)
 }

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/IndexedDbInstance.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/IndexedDbInstance.kt
@@ -48,6 +48,18 @@ internal object IndexedDbInstance {
     nodesStore.createIndex("isDeleted", KeyPath("isDeleted"), unique = false)
     nodesStore.createIndex("updatedAt", KeyPath("updatedAt"), unique = false)
     nodesStore.createIndex("dueDate", KeyPath("dueDate"), unique = false)
+    nodesStore.createIndex("firstReview", KeyPath("firstReview"), unique = false)
+    nodesStore.createIndex("lastReview", KeyPath("lastReview"), unique = false)
+    nodesStore.createIndex(
+      "good_phase_due",
+      KeyPath("hasGoodOutgoing", "phase", "dueDate"),
+      unique = false,
+    )
+    nodesStore.createIndex(
+      "good_phase_due_depth_created",
+      KeyPath("hasGoodOutgoing", "phase", "dueDate", "depth", "createdAt"),
+      unique = false,
+    )
 
     val movesStore = database.createObjectStore(MOVES_STORE, KeyPath("origin", "destination"))
     movesStore.createIndex("origin", KeyPath("origin"), unique = false)

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -373,7 +373,8 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
   /**
    * Earliest-due in-session card. [ready] selects `dueDate <= now`, otherwise `dueDate > now`. Runs
    * one bounded cursor per in-session phase on the `good_phase_due` index and keeps the smaller due
-   * date, mirroring the SQL `phase IN (LEARNING, RELEARNING) ORDER BY dueDate ASC LIMIT 1`.
+   * date, mirroring the SQL `phase IN (LEARNING, RELEARNING) ORDER BY dueDate ASC LIMIT 1`. Soft
+   * deleted rows are skipped so the result matches the Room `WHERE isDeleted = 0` queries.
    */
   private suspend fun nextLearningCard(dueBound: Double, ready: Boolean): TrainingEntry? {
     val database = db()
@@ -394,11 +395,13 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
               lowerOpen = true,
             )
           }
+        // The index orders by due date ascending, so the first non-deleted row of this phase is the
+        // earliest-due live candidate; deleted rows are skipped in place.
         val candidate =
           index
             .openCursor(range, Cursor.Direction.Next)
             .map { it.value as JsNodeEntity }
-            .firstOrNull()
+            .firstOrNull { !it.isDeleted }
         if (candidate != null && (best == null || candidate.dueDate < best.dueDate)) {
           best = candidate
         }
@@ -428,10 +431,11 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
   }
 
   /**
-   * All trainable rows of [phase] due before [dayEnd], read from the bounded compound range on
-   * `good_phase_due_depth_created`. The set is bounded to the due rows of one phase; the caller
+   * All trainable, live rows of [phase] due before [dayEnd], read from the bounded compound range
+   * on `good_phase_due_depth_created`. The set is bounded to the due rows of one phase; the caller
    * reduces it by the tier's ordering (`depth`, or `depth` then `createdAt`) because the index
-   * orders by due date first.
+   * orders by due date first. Soft deleted rows are excluded to match the Room `WHERE isDeleted =
+   * 0` queries.
    */
   private suspend fun com.juul.indexeddb.Transaction.dueGoodRows(
     phase: String,
@@ -448,6 +452,7 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
       .openCursor(range, Cursor.Direction.Next)
       .map { it.value as JsNodeEntity }
       .toList()
+      .filter { !it.isDeleted }
   }
 
   override suspend fun getSchedulingCounts(
@@ -459,21 +464,44 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
     val end = dayEndExclusive.epochSeconds.toDouble()
     return database.transaction(NODES_STORE) {
       val store = objectStore(NODES_STORE)
+      // firstReview/lastReview store the "never reviewed" null as the 0.0 sentinel, so a day window
+      // that begins at epoch 0 would otherwise sweep those nulls in. Excluding values <= 0.0 keeps
+      // parity with Room (NULL excluded) and InMemory regardless of where the window starts.
       val introduced =
-        store.index("firstReview").count(bound(start.toJsKey(), end.toJsKey(), upperOpen = true))
+        store
+          .index("firstReview")
+          .openCursor(
+            bound(start.toJsKey(), end.toJsKey(), upperOpen = true),
+            Cursor.Direction.Next,
+          )
+          .map { it.value as JsNodeEntity }
+          .toList()
+          .count { !it.isDeleted && it.firstReview > 0.0 }
       val trained =
-        store.index("lastReview").count(bound(start.toJsKey(), end.toJsKey(), upperOpen = true))
-      val dueReviews = dueGoodCount(store, CardPhase.REVIEW.name, end)
-      val dueNew = dueGoodCount(store, CardPhase.NEW.name, end)
+        store
+          .index("lastReview")
+          .openCursor(
+            bound(start.toJsKey(), end.toJsKey(), upperOpen = true),
+            Cursor.Direction.Next,
+          )
+          .map { it.value as JsNodeEntity }
+          .toList()
+          .count { !it.isDeleted && it.lastReview > 0.0 }
+      val dueReviews = dueGoodRows(phase = CardPhase.REVIEW.name, dayEnd = end).size
+      val dueNew = dueGoodRows(phase = CardPhase.NEW.name, dayEnd = end).size
       val inSession = IN_SESSION_PHASES.sumOf { phase ->
         store
           .index("good_phase_due")
-          .count(
+          .openCursor(
             bound(
               jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER),
               jsKeyArray(GOOD, phase.toJsString(), HIGH_NUMBER),
-            )
+            ),
+            Cursor.Direction.Next,
           )
+          .map { it.value as JsNodeEntity }
+          .toList()
+          .count { !it.isDeleted }
       }
       SchedulingCounts(
         introducedToday = introduced,
@@ -484,22 +512,6 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
       )
     }
   }
-
-  /** Count of trainable rows of [phase] due before [dayEnd] via the compound index range. */
-  private suspend fun com.juul.indexeddb.Transaction.dueGoodCount(
-    store: com.juul.indexeddb.ObjectStore,
-    phase: String,
-    dayEnd: Double,
-  ): Int =
-    store
-      .index("good_phase_due")
-      .count(
-        bound(
-          jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER),
-          jsKeyArray(GOOD, phase.toJsString(), dayEnd.toJsKey()),
-          upperOpen = true,
-        )
-      )
 
   override suspend fun findEligibleAmong(
     keys: List<PositionKey>,

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -6,16 +6,21 @@ package proj.memorchess.axl.core.data
 import com.juul.indexeddb.Cursor
 import com.juul.indexeddb.Database
 import com.juul.indexeddb.Key
+import com.juul.indexeddb.bound
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.JsAny
 import kotlin.js.JsArray
+import kotlin.js.set
+import kotlin.js.toJsNumber
 import kotlin.js.toJsString
 import kotlin.time.Instant
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import proj.memorchess.axl.core.date.DateUtil.truncateToSeconds
 import proj.memorchess.axl.core.graph.DeleteMode
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
+import proj.memorchess.axl.core.graph.TrainingEntry
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 
@@ -122,6 +127,50 @@ private fun JsNodeEntity.toDataNode(
   )
 }
 
+/**
+ * Builds a [proj.memorchess.axl.core.graph.TrainingEntry] from a node row without loading any
+ * edges, the IndexedDB counterpart of the Room `NodeCardProjection` mapping.
+ */
+private fun JsNodeEntity.toTrainingEntry(): TrainingEntry {
+  val lastReviewSec = lastReview.toLong()
+  val firstReviewSec = firstReview.toLong()
+  return TrainingEntry(
+    PositionKey(positionKey),
+    CardState(
+      dueDate = Instant.fromEpochSeconds(dueDate.toLong()),
+      lastReview = if (lastReviewSec == 0L) null else Instant.fromEpochSeconds(lastReviewSec),
+      firstReview = if (firstReviewSec == 0L) null else Instant.fromEpochSeconds(firstReviewSec),
+      stability = stability,
+      difficulty = difficulty,
+      reps = reps,
+      lapses = lapses,
+      phase = runCatching { CardPhase.valueOf(phase) }.getOrDefault(CardPhase.NEW),
+      step = step,
+    ),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Compound IndexedDB key range helpers
+// ---------------------------------------------------------------------------
+
+/** Builds a JS array usable as a compound IndexedDB key from already-JS values. */
+private fun jsKeyArray(vararg elements: JsAny): JsArray<JsAny> {
+  val array = JsArray<JsAny>()
+  for ((index, element) in elements.withIndex()) {
+    array[index] = element
+  }
+  return array
+}
+
+private fun Int.toJsKey(): JsAny = toDouble().toJsNumber()
+
+private fun Double.toJsKey(): JsAny = toJsNumber()
+
+// Sentinels spanning the full ordered domain of a compound key slot.
+private val LOW_NUMBER: JsAny = Double.NEGATIVE_INFINITY.toJsNumber()
+private val HIGH_NUMBER: JsAny = Double.POSITIVE_INFINITY.toJsNumber()
+
 // ---------------------------------------------------------------------------
 // Conversion: domain → JS
 // ---------------------------------------------------------------------------
@@ -173,6 +222,12 @@ internal const val MOVES_STORE = "moves"
 internal const val EXPLORER_CACHE_STORE = "explorerCache"
 internal const val DB_NAME = "memorchess"
 internal const val DB_VERSION = 7
+
+/** Compound-key value for `hasGoodOutgoing = true`, encoded as the integer `1`. */
+private val GOOD: JsAny = 1.toJsKey()
+
+/** The two in-session phases, used to span both LEARNING and RELEARNING with bounded queries. */
+private val IN_SESSION_PHASES = listOf(CardPhase.LEARNING.name, CardPhase.RELEARNING.name)
 
 // ---------------------------------------------------------------------------
 // IndexedDB-backed DatabaseQueryManager
@@ -306,6 +361,164 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
     database.writeTransaction(NODES_STORE, MOVES_STORE) {
       objectStore(MOVES_STORE).clear()
       objectStore(NODES_STORE).clear()
+    }
+  }
+
+  override suspend fun nextReadyLearningCard(now: Instant): TrainingEntry? =
+    nextLearningCard(dueBound = now.epochSeconds.toDouble(), ready = true)
+
+  override suspend fun nextPendingLearningCard(now: Instant): TrainingEntry? =
+    nextLearningCard(dueBound = now.epochSeconds.toDouble(), ready = false)
+
+  /**
+   * Earliest-due in-session card. [ready] selects `dueDate <= now`, otherwise `dueDate > now`. Runs
+   * one bounded cursor per in-session phase on the `good_phase_due` index and keeps the smaller due
+   * date, mirroring the SQL `phase IN (LEARNING, RELEARNING) ORDER BY dueDate ASC LIMIT 1`.
+   */
+  private suspend fun nextLearningCard(dueBound: Double, ready: Boolean): TrainingEntry? {
+    val database = db()
+    return database.transaction(NODES_STORE) {
+      val index = objectStore(NODES_STORE).index("good_phase_due")
+      var best: JsNodeEntity? = null
+      for (phase in IN_SESSION_PHASES) {
+        val range =
+          if (ready) {
+            bound(
+              jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER),
+              jsKeyArray(GOOD, phase.toJsString(), dueBound.toJsKey()),
+            )
+          } else {
+            bound(
+              jsKeyArray(GOOD, phase.toJsString(), dueBound.toJsKey()),
+              jsKeyArray(GOOD, phase.toJsString(), HIGH_NUMBER),
+              lowerOpen = true,
+            )
+          }
+        val candidate =
+          index
+            .openCursor(range, Cursor.Direction.Next)
+            .map { it.value as JsNodeEntity }
+            .firstOrNull()
+        if (candidate != null && (best == null || candidate.dueDate < best.dueDate)) {
+          best = candidate
+        }
+      }
+      best?.toTrainingEntry()
+    }
+  }
+
+  override suspend fun nextDueReviewCard(dayEndExclusive: Instant): TrainingEntry? {
+    val database = db()
+    val end = dayEndExclusive.epochSeconds.toDouble()
+    return database.transaction(NODES_STORE) {
+      dueGoodRows(phase = CardPhase.REVIEW.name, dayEnd = end)
+        .minWithOrNull(compareBy { it.depth })
+        ?.toTrainingEntry()
+    }
+  }
+
+  override suspend fun nextDueNewCard(dayEndExclusive: Instant): TrainingEntry? {
+    val database = db()
+    val end = dayEndExclusive.epochSeconds.toDouble()
+    return database.transaction(NODES_STORE) {
+      dueGoodRows(phase = CardPhase.NEW.name, dayEnd = end)
+        .minWithOrNull(compareBy({ it.depth }, { it.createdAt }))
+        ?.toTrainingEntry()
+    }
+  }
+
+  /**
+   * All trainable rows of [phase] due before [dayEnd], read from the bounded compound range on
+   * `good_phase_due_depth_created`. The set is bounded to the due rows of one phase; the caller
+   * reduces it by the tier's ordering (`depth`, or `depth` then `createdAt`) because the index
+   * orders by due date first.
+   */
+  private suspend fun com.juul.indexeddb.Transaction.dueGoodRows(
+    phase: String,
+    dayEnd: Double,
+  ): List<JsNodeEntity> {
+    val range =
+      bound(
+        jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER, LOW_NUMBER, LOW_NUMBER),
+        jsKeyArray(GOOD, phase.toJsString(), dayEnd.toJsKey(), LOW_NUMBER, LOW_NUMBER),
+        upperOpen = true,
+      )
+    return objectStore(NODES_STORE)
+      .index("good_phase_due_depth_created")
+      .openCursor(range, Cursor.Direction.Next)
+      .map { it.value as JsNodeEntity }
+      .toList()
+  }
+
+  override suspend fun getSchedulingCounts(
+    dayStart: Instant,
+    dayEndExclusive: Instant,
+  ): SchedulingCounts {
+    val database = db()
+    val start = dayStart.epochSeconds.toDouble()
+    val end = dayEndExclusive.epochSeconds.toDouble()
+    return database.transaction(NODES_STORE) {
+      val store = objectStore(NODES_STORE)
+      val introduced =
+        store.index("firstReview").count(bound(start.toJsKey(), end.toJsKey(), upperOpen = true))
+      val trained =
+        store.index("lastReview").count(bound(start.toJsKey(), end.toJsKey(), upperOpen = true))
+      val dueReviews = dueGoodCount(store, CardPhase.REVIEW.name, end)
+      val dueNew = dueGoodCount(store, CardPhase.NEW.name, end)
+      val inSession = IN_SESSION_PHASES.sumOf { phase ->
+        store
+          .index("good_phase_due")
+          .count(
+            bound(
+              jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER),
+              jsKeyArray(GOOD, phase.toJsString(), HIGH_NUMBER),
+            )
+          )
+      }
+      SchedulingCounts(
+        introducedToday = introduced,
+        trainedToday = trained,
+        dueReviews = dueReviews,
+        dueNew = dueNew,
+        inSession = inSession,
+      )
+    }
+  }
+
+  /** Count of trainable rows of [phase] due before [dayEnd] via the compound index range. */
+  private suspend fun com.juul.indexeddb.Transaction.dueGoodCount(
+    store: com.juul.indexeddb.ObjectStore,
+    phase: String,
+    dayEnd: Double,
+  ): Int =
+    store
+      .index("good_phase_due")
+      .count(
+        bound(
+          jsKeyArray(GOOD, phase.toJsString(), LOW_NUMBER),
+          jsKeyArray(GOOD, phase.toJsString(), dayEnd.toJsKey()),
+          upperOpen = true,
+        )
+      )
+
+  override suspend fun findEligibleAmong(
+    keys: List<PositionKey>,
+    dayEndExclusive: Instant,
+  ): TrainingEntry? {
+    if (keys.isEmpty()) return null
+    val database = db()
+    val end = dayEndExclusive.epochSeconds.toDouble()
+    return database.transaction(NODES_STORE) {
+      val store = objectStore(NODES_STORE)
+      // Bounded by the candidate count (branching factor): one primary-key get per key, in order.
+      for (key in keys) {
+        val node = store.get(Key(key.value.toJsString()))?.unsafeCast<JsNodeEntity>() ?: continue
+        if (node.isDeleted || node.hasGoodOutgoing != 1) continue
+        val inSession =
+          node.phase == CardPhase.LEARNING.name || node.phase == CardPhase.RELEARNING.name
+        if (inSession || node.dueDate < end) return@transaction node.toTrainingEntry()
+      }
+      null
     }
   }
 

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -36,6 +36,8 @@ private external interface JsNodeEntity : JsAny {
   var phase: String // CardPhase name
   var step: Int
   var depth: Int
+  var hasGoodOutgoing: Int // 0/1; IndexedDB cannot range-index a JS boolean directly
+  var createdAt: Double // epoch seconds (Double avoids Long to BigInt)
   var isDeleted: Boolean
   var updatedAt: Double // epoch seconds (Double avoids Long to BigInt)
 }
@@ -115,6 +117,8 @@ private fun JsNodeEntity.toDataNode(
     depth = depth,
     updatedAt = Instant.fromEpochSeconds(updatedAt.toLong()),
     isDeleted = isDeleted,
+    hasGoodOutgoing = hasGoodOutgoing == 1,
+    createdAt = Instant.fromEpochSeconds(createdAt.toLong()),
   )
 }
 
@@ -136,6 +140,8 @@ private fun DataNode.toJsNodeEntity(): JsNodeEntity {
     phase = node.cardState.phase.name
     step = node.cardState.step
     depth = node.depth
+    hasGoodOutgoing = if (node.hasGoodOutgoing) 1 else 0
+    createdAt = node.createdAt.epochSeconds.toDouble()
     isDeleted = node.isDeleted
     updatedAt = node.updatedAt.epochSeconds.toDouble()
   }
@@ -166,7 +172,7 @@ internal const val NODES_STORE = "nodes"
 internal const val MOVES_STORE = "moves"
 internal const val EXPLORER_CACHE_STORE = "explorerCache"
 internal const val DB_NAME = "memorchess"
-internal const val DB_VERSION = 6
+internal const val DB_VERSION = 7
 
 // ---------------------------------------------------------------------------
 // IndexedDB-backed DatabaseQueryManager

--- a/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
+++ b/microbenchmark/src/main/kotlin/proj/memorchess/axl/microbenchmark/NoOpDatabaseQueryManager.kt
@@ -4,7 +4,9 @@ import kotlin.time.Instant
 import proj.memorchess.axl.core.data.DataNode
 import proj.memorchess.axl.core.data.DatabaseQueryManager
 import proj.memorchess.axl.core.data.PositionKey
+import proj.memorchess.axl.core.data.SchedulingCounts
 import proj.memorchess.axl.core.graph.DeleteMode
+import proj.memorchess.axl.core.graph.TrainingEntry
 
 /**
  * [DatabaseQueryManager] that persists nothing.
@@ -28,4 +30,22 @@ class NoOpDatabaseQueryManager : DatabaseQueryManager {
   override suspend fun insertNodes(vararg positions: DataNode) = Unit
 
   override suspend fun getLastUpdate(): Instant? = null
+
+  override suspend fun nextReadyLearningCard(now: Instant): TrainingEntry? = null
+
+  override suspend fun nextPendingLearningCard(now: Instant): TrainingEntry? = null
+
+  override suspend fun nextDueReviewCard(dayEndExclusive: Instant): TrainingEntry? = null
+
+  override suspend fun nextDueNewCard(dayEndExclusive: Instant): TrainingEntry? = null
+
+  override suspend fun getSchedulingCounts(
+    dayStart: Instant,
+    dayEndExclusive: Instant,
+  ): SchedulingCounts = SchedulingCounts(0, 0, 0, 0, 0)
+
+  override suspend fun findEligibleAmong(
+    keys: List<PositionKey>,
+    dayEndExclusive: Instant,
+  ): TrainingEntry? = null
 }


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Summary

Phase 1 of the incremental-loading refactor. The training scheduler no longer scans the full opening graph in memory to decide what to train next. Instead it drives off bounded persistence queries against newly derived, persisted node columns, so scheduling cost no longer grows with the size of the repertoire.

What changed:

- Added two derived, persisted node columns: `hasGoodOutgoing: Boolean` and `createdAt: Instant`. These are maintained on every write through `TreeStore` (the `hasGoodOutgoing` projection is recomputed on persist and re-persisted on edge/node deletion so a stale `true` cannot linger; `createdAt` is the earliest incoming-edge creation time, falling back to now for the root).
- Persisted the new columns across all three backends: Room (`nonJsMain`, schema bumped to v8 with composite indexes covering the scheduling predicates), IndexedDB (`wasmJsMain`, `DB_VERSION` bumped to 7 with matching indexes), and the in-memory backend.
- Declared a bounded scheduling query surface on `DatabaseQueryManager` (next ready/pending learning card, next due review/new card, scheduling counts, eligible-among) and implemented it on all three backends. New cards are ordered by `depth ASC, createdAt ASC`.
- Rewrote `TrainingScheduler` to consume those bounded queries. It holds no graph and no longer calls `introductionOrder()`, `snapshot()`, or `getDepth()`.

Verification:

- `./gradlew :composeApp:jvmTest`: 414 tests, 0 failures, 0 errors (Room exercised via `BundledSQLiteDriver`).
- `./gradlew :composeApp:compileKotlinWasmJs`: compiles.
- `./gradlew ktfmtFormat`: no changes.

Scope note: `getAllNodes` and the eager `TreeStore.load()` that mirrors the graph for the explorer still exist. They are removed in later phases of this refactor.

Part of #226
