### PR TITLE
perf(data): streaming export + remove getAllNodes (incremental loading phase 3)

### DIFF
--- a/androidApp/src/androidTest/kotlin/proj/memorchess/axl/database/TestNodeEntitiesDataBase.kt
+++ b/androidApp/src/androidTest/kotlin/proj/memorchess/axl/database/TestNodeEntitiesDataBase.kt
@@ -52,7 +52,7 @@ class TestNodeEntitiesDataBase {
           )
         )
       )
-      retrievedNodes = nodeEntityDao.getAllNodes()
+      retrievedNodes = nodeEntityDao.getNodesPage(PAGE_LIMIT)
     }
     assertEquals(1, retrievedNodes.size)
     assertNotNull(retrievedNodes.first())
@@ -73,7 +73,7 @@ class TestNodeEntitiesDataBase {
         )
       )
       nodeEntityDao.eraseAllNodes()
-      retrievedNode = nodeEntityDao.getAllNodes().firstOrNull { !it.node.isDeleted }
+      retrievedNode = nodeEntityDao.getNodesPage(PAGE_LIMIT).firstOrNull()
     }
     assertNull(retrievedNode)
   }
@@ -99,7 +99,7 @@ class TestNodeEntitiesDataBase {
       nodeEntityDao.insertNodeAndMoves(listOf(NodeWithMoves.convertToEntity(rootNode)))
       nodeEntityDao.insertNodeAndMoves(listOf(NodeWithMoves.convertToEntity(childNode)))
       nodeEntityDao.softDeleteNode(childNode.positionKey.value)
-      retrievedNodes = nodeEntityDao.getAllNodes().filter { !it.node.isDeleted }
+      retrievedNodes = nodeEntityDao.getNodesPage(PAGE_LIMIT)
     }
     assertEquals(1, retrievedNodes.size)
     assertContains(
@@ -107,5 +107,10 @@ class TestNodeEntitiesDataBase {
       linkMove.toStoredMove(),
     )
     assertEquals(rootPositionKey, retrievedNodes.first().toStoredNode().positionKey)
+  }
+
+  private companion object {
+    /** Bounded page size large enough to read back every node these tiny fixtures insert. */
+    const val PAGE_LIMIT = 100
   }
 }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
@@ -13,13 +13,6 @@ import proj.memorchess.axl.core.graph.TrainingEntry
  */
 interface DatabaseQueryManager {
 
-  /**
-   * Retrieves all stored positions.
-   *
-   * @param withDeletedOnes When `true`, includes rows flagged with [DataNode.isDeleted].
-   */
-  suspend fun getAllNodes(withDeletedOnes: Boolean = false): List<DataNode>
-
   /** Retrieves a specific position, or `null` when missing or soft deleted. */
   suspend fun getPosition(positionKey: PositionKey): DataNode?
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/DatabaseQueryManager.kt
@@ -24,6 +24,27 @@ interface DatabaseQueryManager {
   suspend fun getPosition(positionKey: PositionKey): DataNode?
 
   /**
+   * Reads one bounded page of non deleted nodes ordered by position key ascending.
+   *
+   * This is the only multi row read on the seam and it is bounded by [limit] plus an explicit
+   * [cursor], so no query ever pulls the whole store into memory. Each returned node carries its
+   * edges, exactly as a single read would reconstruct them.
+   *
+   * Paging contract: pass `null` as [cursor] for the first page; thereafter pass the previous
+   * page's [NodesPage.nextCursor]. The page contains the rows with `positionKey > cursor` ordered
+   * ascending, capped at [limit]. [NodesPage.nextCursor] is the last returned node's position key
+   * when a full [limit] sized page was returned (more rows may remain), and `null` once a partial
+   * page is returned, which terminates the loop. A store size that is an exact multiple of [limit]
+   * therefore ends with one trailing empty page whose cursor is `null`.
+   *
+   * @param cursor The position key of the last node of the previous page, or `null` for the first
+   *   page.
+   * @param limit The maximum number of nodes to return; must be strictly positive.
+   * @throws IllegalArgumentException when [limit] is not strictly positive.
+   */
+  suspend fun getNodesPage(cursor: String?, limit: Int): NodesPage
+
+  /**
    * Deletes a single position and any incident moves.
    *
    * @param position Position to remove.

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -28,6 +28,21 @@ class InMemoryDatabaseQueryManager : DatabaseQueryManager {
   override suspend fun getPosition(positionKey: PositionKey): DataNode? =
     nodes[positionKey]?.takeIf { !it.isDeleted }
 
+  override suspend fun getNodesPage(cursor: String?, limit: Int): NodesPage {
+    require(limit > 0) { "Page limit must be strictly positive, was $limit" }
+    // Sorting and slicing the backing map is acceptable here precisely because this is the
+    // throwaway
+    // in memory store, not the disk backed path: the Room and IndexedDB backends express the same
+    // ordered, cursor bounded slice as a single bounded query.
+    val page =
+      live()
+        .filter { cursor == null || it.positionKey.value > cursor }
+        .sortedBy { it.positionKey.value }
+        .take(limit)
+    val nextCursor = if (page.size == limit) page.last().positionKey.value else null
+    return NodesPage(page, nextCursor)
+  }
+
   override suspend fun insertNodes(vararg positions: DataNode) {
     positions.forEach { nodes[it.positionKey] = it }
   }

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/InMemoryDatabaseQueryManager.kt
@@ -22,9 +22,6 @@ class InMemoryDatabaseQueryManager : DatabaseQueryManager {
   /** Backing store, keyed by position. Soft-deleted nodes stay here with their flag set. */
   private val nodes: MutableMap<PositionKey, DataNode> = mutableMapOf()
 
-  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> =
-    nodes.values.filter { withDeletedOnes || !it.isDeleted }.toList()
-
   override suspend fun getPosition(positionKey: PositionKey): DataNode? =
     nodes[positionKey]?.takeIf { !it.isDeleted }
 

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/NodesPage.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/data/NodesPage.kt
@@ -1,0 +1,17 @@
+package proj.memorchess.axl.core.data
+
+/**
+ * One bounded page of stored nodes, ordered by [DataNode.positionKey] ascending.
+ *
+ * Returned by [DatabaseQueryManager.getNodesPage], the only multi row read left on the persistence
+ * seam. The page never exceeds the requested limit, so the cost is constant regardless of
+ * repertoire size. A consumer drains the whole store by following [nextCursor] until it is `null`.
+ *
+ * @property nodes The nodes in this page, each carrying its edges, ordered by position key
+ *   ascending. Soft deleted rows are excluded.
+ * @property nextCursor The last node's position key when a full limit sized page was returned and
+ *   more rows may remain, used as the `cursor` of the next [DatabaseQueryManager.getNodesPage]
+ *   call. `null` when this is the last page (fewer than limit rows were returned), which terminates
+ *   the paging loop.
+ */
+data class NodesPage(val nodes: List<DataNode>, val nextCursor: String?)

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/core/graph/GraphSerializer.kt
@@ -3,6 +3,7 @@ package proj.memorchess.axl.core.graph
 import kotlin.time.Instant
 import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.NodesPage
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
@@ -38,50 +39,133 @@ object GraphSerializer {
     val sorted = liveNodes.sortedBy { it.positionKey.value }
     val indexByKey = buildMap { sorted.forEachIndexed { i, node -> put(node.positionKey, i + 1) } }
 
-    val nodeLines = sorted.mapIndexed { i, node ->
-      val idx = i + 1
-      val card = node.cardState
-      listOf(
-          idx,
-          node.positionKey.value,
-          node.depth,
-          card.dueDate,
-          card.lastReview?.toString() ?: NULL_TOKEN,
-          card.stability,
-          card.difficulty,
-          card.reps,
-          card.lapses,
-          card.phase.name,
-          card.step,
-          node.updatedAt,
-          card.firstReview?.toString() ?: NULL_TOKEN,
-        )
-        .joinToString(TAB)
-    }
+    val nodeLines = sorted.mapIndexed { i, node -> nodeLine(i + 1, node) }
 
     val edges = buildList {
       for (node in sorted) {
-        val originIdx = indexByKey[node.positionKey]!!
-        for (dataMove in node.previousAndNextMoves.filterNotDeleted().nextMoves.values) {
-          val destIdx = indexByKey[dataMove.destination] ?: continue
-          add(
-            Edge(
-              originIdx,
-              destIdx,
-              dataMove.move,
-              dataMove.isGood,
-              dataMove.updatedAt,
-              dataMove.createdAt,
-            )
-          )
-        }
+        addEdgesOf(node, indexByKey[node.positionKey]!!, indexByKey)
       }
     }
-    val sortedEdges = edges.sortedWith(compareBy({ it.originIndex }, { it.destIndex }, { it.move }))
-    val edgeLines = sortedEdges.map { it.toLine() }
+    val edgeLines = sortEdges(edges).map { it.toLine() }
 
     return nodeLines.joinToString("\n") + SECTION_SEPARATOR + edgeLines.joinToString("\n")
   }
+
+  /**
+   * Streams a deterministic serialization without ever holding all rows in memory.
+   *
+   * Produces the exact same bytes as [serialize] called on the whole store, but sources the rows
+   * through two bounded paginated scans of [pageProducer] instead of one eager list. The first scan
+   * emits every node line page by page while building only a `positionKey -> index` map (keys and
+   * ints, not full rows). The second scan re-pages the store to collect and sort the edges. The two
+   * section (nodes then edges) on disk format is therefore byte stable and the deserializer is
+   * untouched.
+   *
+   * The position key ordering of [NodesPage] matches the `sortedBy { positionKey.value }` order
+   * [serialize] uses, so indices assigned by the incrementing page counter are identical to the
+   * eager path.
+   *
+   * @param pageSize Maximum rows per page; forwarded as the `limit` to [pageProducer]. Must be
+   *   strictly positive.
+   * @param pageProducer Bounded page source, typically
+   *   [proj.memorchess.axl.core.data.DatabaseQueryManager.getNodesPage]. Called with `null` for the
+   *   first page then the previous page's [NodesPage.nextCursor] until it is `null`.
+   * @throws IllegalArgumentException when [pageSize] is not strictly positive.
+   */
+  suspend fun serializeStreaming(
+    pageSize: Int,
+    pageProducer: suspend (cursor: String?, limit: Int) -> NodesPage,
+  ): String {
+    require(pageSize > 0) { "pageSize must be strictly positive, was $pageSize" }
+
+    val nodeLines = StringBuilder()
+    val indexByKey = mutableMapOf<PositionKey, Int>()
+    var index = 0
+    forEachPage(pageSize, pageProducer) { page ->
+      for (node in page.nodes) {
+        index += 1
+        indexByKey[node.positionKey] = index
+        if (nodeLines.isNotEmpty()) nodeLines.append("\n")
+        nodeLines.append(nodeLine(index, node))
+      }
+    }
+
+    val edges = mutableListOf<Edge>()
+    forEachPage(pageSize, pageProducer) { page ->
+      for (node in page.nodes) {
+        val originIdx = indexByKey[node.positionKey] ?: continue
+        edges.addEdgesOf(node, originIdx, indexByKey)
+      }
+    }
+    val edgeLines = sortEdges(edges).joinToString("\n") { it.toLine() }
+
+    return nodeLines.toString() + SECTION_SEPARATOR + edgeLines
+  }
+
+  /**
+   * Drains every page in order, invoking [block] on each, until [NodesPage.nextCursor] is `null`.
+   */
+  private suspend inline fun forEachPage(
+    pageSize: Int,
+    pageProducer: suspend (cursor: String?, limit: Int) -> NodesPage,
+    block: (NodesPage) -> Unit,
+  ) {
+    var cursor: String? = null
+    do {
+      val page = pageProducer(cursor, pageSize)
+      block(page)
+      cursor = page.nextCursor
+    } while (cursor != null)
+  }
+
+  /** Builds the deterministic node line for [node] at the one based serialization [index]. */
+  private fun nodeLine(index: Int, node: DataNode): String {
+    val card = node.cardState
+    return listOf(
+        index,
+        node.positionKey.value,
+        node.depth,
+        card.dueDate,
+        card.lastReview?.toString() ?: NULL_TOKEN,
+        card.stability,
+        card.difficulty,
+        card.reps,
+        card.lapses,
+        card.phase.name,
+        card.step,
+        node.updatedAt,
+        card.firstReview?.toString() ?: NULL_TOKEN,
+      )
+      .joinToString(TAB)
+  }
+
+  /**
+   * Appends [node]'s non deleted outgoing edges to the receiver, skipping any whose destination is
+   * absent from [indexByKey].
+   */
+  private fun MutableList<Edge>.addEdgesOf(
+    node: DataNode,
+    originIdx: Int,
+    indexByKey: Map<PositionKey, Int>,
+  ) {
+    for (dataMove in node.previousAndNextMoves.filterNotDeleted().nextMoves.values) {
+      val destIdx = indexByKey[dataMove.destination] ?: continue
+      add(
+        Edge(
+          originIdx,
+          destIdx,
+          dataMove.move,
+          dataMove.isGood,
+          dataMove.updatedAt,
+          dataMove.createdAt,
+        )
+      )
+    }
+  }
+
+  /** Orders edges by `(originIndex, destIndex, move)` for a deterministic edge section. */
+  private fun sortEdges(edges: List<Edge>): List<Edge> =
+    edges.sortedWith(compareBy({ it.originIndex }, { it.destIndex }, { it.move }))
 
   /**
    * Deserializes text back to a list of [DataNode]s. Throws [IllegalArgumentException] on bad

--- a/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/settings/sections/ImportExportSection.kt
+++ b/composeApp/src/commonMain/kotlin/proj/memorchess/axl/ui/components/settings/sections/ImportExportSection.kt
@@ -50,6 +50,9 @@ import proj.memorchess.axl.ui.components.buttons.KineticButtonStyle
 import proj.memorchess.axl.ui.components.popup.ConfirmationDialog
 import proj.memorchess.axl.ui.util.exportToFile
 
+/** Rows fetched per bounded page when streaming the export to disk. */
+private const val EXPORT_PAGE_SIZE = 256
+
 /**
  * Import / Export settings section content.
  *
@@ -86,8 +89,12 @@ private fun FileButtonsRow(database: DatabaseQueryManager, dlg: ConfirmationDial
     KineticButton(
       onClick = {
         coroutineScope.launch {
-          val nodes = database.getAllNodes()
-          val content = GraphSerializer.serialize(nodes)
+          // Stream the export through bounded pages so the whole store is never held in memory at
+          // once; the serialized bytes are identical to an eager serialize of every node.
+          val content =
+            GraphSerializer.serializeStreaming(EXPORT_PAGE_SIZE) { cursor, limit ->
+              database.getNodesPage(cursor, limit)
+            }
           val baseName = "openings-${DateUtil.today()}"
           exportToFile(content, baseName, "memorchess")
         }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
@@ -13,6 +13,7 @@ import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 import proj.memorchess.axl.core.scheduling.CardStateFactory
+import proj.memorchess.axl.test_util.drainAllNodes
 
 /**
  * Direct branch coverage for [InMemoryDatabaseQueryManager]: insert/query, hard and soft deletes of
@@ -53,7 +54,7 @@ class TestInMemoryDatabaseQueryManager {
   @Test
   fun insertsAndReadsBack() = runTest {
     val database = seededLine()
-    assertEquals(3, database.getAllNodes().size)
+    assertEquals(3, drainAllNodes(database).size)
     assertEquals(setOf("e5"), database.getPosition(key1)?.previousAndNextMoves?.nextMoves?.keys)
   }
 
@@ -67,7 +68,7 @@ class TestInMemoryDatabaseQueryManager {
     val database = seededLine()
     database.deletePosition(key1, DeleteMode.HARD)
     assertNull(database.getPosition(key1))
-    assertEquals(2, database.getAllNodes().size)
+    assertEquals(2, drainAllNodes(database).size)
     // e4 pointed at key1, e5 came from key1: both are gone from the surviving neighbours.
     assertTrue(database.getPosition(key0)!!.previousAndNextMoves.nextMoves.isEmpty())
     assertTrue(database.getPosition(key2)!!.previousAndNextMoves.previousMoves.isEmpty())
@@ -86,21 +87,20 @@ class TestInMemoryDatabaseQueryManager {
   }
 
   @Test
-  fun softDeletingAPositionHidesItButKeepsTheRow() = runTest {
+  fun softDeletingAPositionHidesItFromReads() = runTest {
     val database = seededLine()
     database.deletePosition(key1, DeleteMode.SOFT)
+    // A soft deleted position is hidden from every read: the point lookup returns null and the
+    // position drops out of the paged live read, leaving the two surviving rows.
     assertNull(database.getPosition(key1))
-    assertEquals(2, database.getAllNodes().size)
-    val withDeleted = database.getAllNodes(withDeletedOnes = true)
-    assertEquals(3, withDeleted.size)
-    assertTrue(withDeleted.single { it.positionKey == key1 }.isDeleted)
+    assertEquals(2, drainAllNodes(database).size)
   }
 
   @Test
   fun deletingAMissingPositionIsANoOp() = runTest {
     val database = seededLine()
     database.deletePosition(keyAfter("d4"), DeleteMode.HARD)
-    assertEquals(3, database.getAllNodes().size)
+    assertEquals(3, drainAllNodes(database).size)
   }
 
   @Test
@@ -159,7 +159,7 @@ class TestInMemoryDatabaseQueryManager {
   fun eraseAllClearsEverything() = runTest {
     val database = seededLine()
     database.eraseAll()
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
   }
 
   @Test
@@ -531,7 +531,7 @@ class TestInMemoryDatabaseQueryManager {
   fun getNodesPage_carriesEdgesLikeASingleRead() = runTest {
     val database = seededLine()
     val byKey = database.pageAll(limit = 1).associateBy { it.positionKey }
-    // The page read reconstructs the same node set and edges as getAllNodes would.
+    // The page read reconstructs the same node set and edges as a single point read would.
     assertEquals(setOf("e4"), byKey.getValue(key0).previousAndNextMoves.nextMoves.keys)
     assertEquals(setOf("e4"), byKey.getValue(key1).previousAndNextMoves.previousMoves.keys)
     assertEquals(setOf("e5"), byKey.getValue(key1).previousAndNextMoves.nextMoves.keys)

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/TestInMemoryDatabaseQueryManager.kt
@@ -2,6 +2,7 @@ package proj.memorchess.axl.core.data
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
@@ -450,6 +451,118 @@ class TestInMemoryDatabaseQueryManager {
     )
     // key0 and key1 are counted; key2 is convergent and excluded.
     assertEquals(2, database.countDescendants(key0))
+  }
+
+  // --- getNodesPage -------------------------------------------------------------------------
+
+  /** Drains the whole store one page of [limit] at a time, returning the visited keys in order. */
+  private suspend fun DatabaseQueryManager.pageAllKeys(limit: Int): List<PositionKey> {
+    val visited = mutableListOf<PositionKey>()
+    var cursor: String? = null
+    while (true) {
+      val page = getNodesPage(cursor, limit)
+      visited += page.nodes.map { it.positionKey }
+      cursor = page.nextCursor ?: break
+    }
+    return visited
+  }
+
+  /** Inserts [count] synthetic nodes whose keys sort deterministically, returns them ascending. */
+  private suspend fun InMemoryDatabaseQueryManager.seedPageable(count: Int): List<PositionKey> {
+    val keys = (0 until count).map { PositionKey("page${it.toString().padStart(3, '0')}") }
+    insertNodes(*keys.map { countNode(it, previous = listOf(), next = listOf()) }.toTypedArray())
+    return keys.sortedBy { it.value }
+  }
+
+  @Test
+  fun getNodesPage_pagingTheWholeStoreVisitsEveryNodeExactlyOnce() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val expected = database.seedPageable(7)
+    // A page size that does not divide the store size exercises a non-empty final page.
+    val visited = database.pageAllKeys(limit = 3)
+    assertEquals(expected, visited)
+    assertEquals(7, visited.toSet().size)
+  }
+
+  @Test
+  fun getNodesPage_lastPageHasNullNextCursor() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    database.seedPageable(2)
+    val first = database.getNodesPage(cursor = null, limit = 2)
+    // A full page that exactly drains the store still advertises a cursor; the follow-up page is
+    // empty and terminates with a null cursor.
+    assertEquals(2, first.nodes.size)
+    assertEquals(
+      database.getPosition(first.nodes.last().positionKey)!!.positionKey.value,
+      first.nextCursor,
+    )
+    val second = database.getNodesPage(cursor = first.nextCursor, limit = 2)
+    assertTrue(second.nodes.isEmpty())
+    assertNull(second.nextCursor)
+  }
+
+  @Test
+  fun getNodesPage_limitLargerThanStoreReturnsEverythingWithNullCursor() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val expected = database.seedPageable(3)
+    val page = database.getNodesPage(cursor = null, limit = 100)
+    assertEquals(expected, page.nodes.map { it.positionKey })
+    // A partial page (fewer than limit rows) is the last page, so the cursor is null.
+    assertNull(page.nextCursor)
+  }
+
+  @Test
+  fun getNodesPage_storeSizeExactMultipleOfLimitTerminatesOnEmptyPage() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    val expected = database.seedPageable(6)
+    // Six rows in pages of two: three full pages then an empty terminating page.
+    val visited = database.pageAllKeys(limit = 2)
+    assertEquals(expected, visited)
+  }
+
+  @Test
+  fun getNodesPage_emptyStoreReturnsEmptyPageWithNullCursor() = runTest {
+    val page = InMemoryDatabaseQueryManager().getNodesPage(cursor = null, limit = 5)
+    assertTrue(page.nodes.isEmpty())
+    assertNull(page.nextCursor)
+  }
+
+  @Test
+  fun getNodesPage_carriesEdgesLikeASingleRead() = runTest {
+    val database = seededLine()
+    val byKey = database.pageAll(limit = 1).associateBy { it.positionKey }
+    // The page read reconstructs the same node set and edges as getAllNodes would.
+    assertEquals(setOf("e4"), byKey.getValue(key0).previousAndNextMoves.nextMoves.keys)
+    assertEquals(setOf("e4"), byKey.getValue(key1).previousAndNextMoves.previousMoves.keys)
+    assertEquals(setOf("e5"), byKey.getValue(key1).previousAndNextMoves.nextMoves.keys)
+  }
+
+  @Test
+  fun getNodesPage_excludesSoftDeletedRows() = runTest {
+    val database = seededLine()
+    database.deletePosition(key1, DeleteMode.SOFT)
+    val keys = database.pageAllKeys(limit = 1)
+    assertEquals(2, keys.size)
+    assertTrue(key1 !in keys)
+  }
+
+  @Test
+  fun getNodesPage_rejectsNonPositiveLimit() = runTest {
+    val database = InMemoryDatabaseQueryManager()
+    assertFailsWith<IllegalArgumentException> { database.getNodesPage(cursor = null, limit = 0) }
+    assertFailsWith<IllegalArgumentException> { database.getNodesPage(cursor = null, limit = -1) }
+  }
+
+  /** Drains the whole store one page of [limit] at a time, returning the visited nodes in order. */
+  private suspend fun DatabaseQueryManager.pageAll(limit: Int): List<DataNode> {
+    val visited = mutableListOf<DataNode>()
+    var cursor: String? = null
+    while (true) {
+      val page = getNodesPage(cursor, limit)
+      visited += page.nodes
+      cursor = page.nextCursor ?: break
+    }
+    return visited
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/study/TestLichessStudyImporter.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/data/study/TestLichessStudyImporter.kt
@@ -16,6 +16,7 @@ import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.engine.GameEngine
 import proj.memorchess.axl.core.pgn.PgnImportSummary
 import proj.memorchess.axl.test_util.TestDatabases
+import proj.memorchess.axl.test_util.drainAllNodes
 import proj.memorchess.axl.test_util.testTreeStore
 
 class TestLichessStudyImporter {
@@ -91,7 +92,7 @@ class TestLichessStudyImporter {
     // Assert
     val error = assertIs<LichessStudyImportResult.FetchFailed>(result).error
     assertEquals(LichessStudyResult.InvalidUrl, error)
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
   }
 
   @Test
@@ -106,7 +107,7 @@ class TestLichessStudyImporter {
     // Assert
     val error = assertIs<LichessStudyImportResult.FetchFailed>(result).error
     assertEquals(LichessStudyResult.NotFound, error)
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
   }
 
   @Test
@@ -119,7 +120,7 @@ class TestLichessStudyImporter {
 
     // Assert
     assertIs<LichessStudyImportResult.ImportFailed>(result)
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
     assertNull(store.node(PositionKey.START_POSITION))
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/graph/TestGraphSerializer.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
 import proj.memorchess.axl.core.data.DataMove
 import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.NodesPage
 import proj.memorchess.axl.core.data.PositionKey
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
@@ -426,5 +428,129 @@ class TestGraphSerializer {
   @Test
   fun emptyStringThrows() {
     shouldThrow<IllegalArgumentException> { GraphSerializer.deserialize("") }
+  }
+
+  /**
+   * Turns an in memory node list into a bounded page producer that mimics
+   * [proj.memorchess.axl.core.data.DatabaseQueryManager.getNodesPage]: live rows ordered by
+   * position key ascending, returning `positionKey > cursor` capped at the page size, with
+   * `nextCursor` set only when a full page was returned.
+   */
+  private fun pagedProducer(
+    nodes: List<DataNode>
+  ): suspend (cursor: String?, limit: Int) -> NodesPage {
+    val sorted = nodes.filter { !it.isDeleted }.sortedBy { it.positionKey.value }
+    return { cursor, limit ->
+      val page = sorted.filter { cursor == null || it.positionKey.value > cursor }.take(limit)
+      val nextCursor = if (page.size == limit) page.last().positionKey.value else null
+      NodesPage(page, nextCursor)
+    }
+  }
+
+  private val complexGraphNodes: List<DataNode>
+    get() {
+      val moveE4 = DataMove(startPos, posAfterE4, "e4", isGood = true, updatedAt = instant1)
+      val moveD4 = DataMove(startPos, posAfterD4, "d4", isGood = true, updatedAt = instant1)
+      val moveE5 = DataMove(posAfterE4, posAfterE4E5, "e5", isGood = true, updatedAt = instant2)
+      return listOf(
+        DataNode(
+          positionKey = startPos,
+          previousAndNextMoves = PreviousAndNextMoves(emptyList(), listOf(moveE4, moveD4)),
+          cardState = cardState(instant1),
+          depth = 0,
+          updatedAt = instant1,
+        ),
+        DataNode(
+          positionKey = posAfterE4,
+          previousAndNextMoves = PreviousAndNextMoves(listOf(moveE4), listOf(moveE5)),
+          cardState = cardState(instant3, instant1),
+          depth = 1,
+          updatedAt = instant1,
+        ),
+        DataNode(
+          positionKey = posAfterD4,
+          previousAndNextMoves = PreviousAndNextMoves(listOf(moveD4), emptyList()),
+          cardState = cardState(instant1),
+          depth = 1,
+          updatedAt = instant1,
+        ),
+        DataNode(
+          positionKey = posAfterE4E5,
+          previousAndNextMoves = PreviousAndNextMoves(listOf(moveE5), emptyList()),
+          cardState = cardState(instant3, instant1),
+          depth = 2,
+          updatedAt = instant2,
+        ),
+      )
+    }
+
+  @Test
+  fun streamedExportIsByteIdenticalToEagerSerialize() = runTest {
+    val nodes = complexGraphNodes
+    val expected = GraphSerializer.serialize(nodes)
+
+    // Several page sizes, including one that splits the store across multiple pages, one that holds
+    // the whole store in a single page, an exact divisor that ends on a trailing empty page, and a
+    // limit larger than the store.
+    for (pageSize in listOf(1, 2, nodes.size, nodes.size + 5)) {
+      val streamed = GraphSerializer.serializeStreaming(pageSize, pagedProducer(nodes))
+      streamed shouldBe expected
+    }
+  }
+
+  @Test
+  fun streamedExportRoundTripsThroughDeserialize() = runTest {
+    val nodes = complexGraphNodes
+
+    val streamed = GraphSerializer.serializeStreaming(2, pagedProducer(nodes))
+    val result = GraphSerializer.deserialize(streamed)
+
+    result shouldHaveSize 4
+    val resultStart = result.first { it.positionKey == startPos }
+    resultStart.previousAndNextMoves.nextMoves.size shouldBe 2
+  }
+
+  @Test
+  fun streamedExportOfEmptyStoreIsByteIdentical() = runTest {
+    val expected = GraphSerializer.serialize(emptyList())
+
+    val streamed = GraphSerializer.serializeStreaming(3, pagedProducer(emptyList()))
+
+    streamed shouldBe expected
+  }
+
+  @Test
+  fun streamedExportExcludesDeletedNodesAndMoves() = runTest {
+    val deletedMove =
+      DataMove(startPos, posAfterE4, "e4", isGood = true, isDeleted = true, updatedAt = instant1)
+    val nodes =
+      listOf(
+        DataNode(
+          positionKey = startPos,
+          previousAndNextMoves = PreviousAndNextMoves(emptyList(), listOf(deletedMove)),
+          cardState = cardState(instant1),
+          depth = 0,
+          updatedAt = instant1,
+        ),
+        DataNode(
+          positionKey = posAfterE4,
+          previousAndNextMoves = PreviousAndNextMoves(listOf(deletedMove), emptyList()),
+          cardState = cardState(instant1),
+          depth = 1,
+          updatedAt = instant1,
+        ),
+      )
+    val expected = GraphSerializer.serialize(nodes)
+
+    val streamed = GraphSerializer.serializeStreaming(1, pagedProducer(nodes))
+
+    streamed shouldBe expected
+  }
+
+  @Test
+  fun streamedExportRejectsNonPositivePageSize() = runTest {
+    shouldThrow<IllegalArgumentException> {
+      GraphSerializer.serializeStreaming(0, pagedProducer(complexGraphNodes))
+    }
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestTrainingNodeOrder.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/interaction/TestTrainingNodeOrder.kt
@@ -12,6 +12,7 @@ import proj.memorchess.axl.core.graph.TrainingScheduler
 import proj.memorchess.axl.core.graph.TreeStore
 import proj.memorchess.axl.test_util.TestDatabases
 import proj.memorchess.axl.test_util.TestWithKoin
+import proj.memorchess.axl.test_util.drainAllNodes
 
 class TestTrainingNodeOrder : TestWithKoin() {
 
@@ -21,7 +22,7 @@ class TestTrainingNodeOrder : TestWithKoin() {
 
   override suspend fun setUp() {
     database.eraseAll()
-    database.insertNodes(*TestDatabases.vienna().getAllNodes(true).toTypedArray())
+    database.insertNodes(*drainAllNodes(TestDatabases.vienna()).toTypedArray())
   }
 
   @Test

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/pgn/TestPgnImporter.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/core/pgn/TestPgnImporter.kt
@@ -12,6 +12,7 @@ import proj.memorchess.axl.core.engine.GameEngine
 import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.core.scheduling.CardStateFactory
 import proj.memorchess.axl.test_util.TestDatabases
+import proj.memorchess.axl.test_util.drainAllNodes
 import proj.memorchess.axl.test_util.testTreeStore
 
 class TestPgnImporter {
@@ -37,17 +38,13 @@ class TestPgnImporter {
 
     // Act
     val firstSummary = importer.import(games)
-    val databaseAfterFirstImport =
-      database.getAllNodes(withDeletedOnes = true).associateBy { it.positionKey }
+    val databaseAfterFirstImport = drainAllNodes(database).associateBy { it.positionKey }
     val secondSummary = importer.import(games)
 
     // Assert
     assertEquals(PgnImportSummary(movesAdded = 4, movesAlreadyPresent = 0), firstSummary)
     assertEquals(PgnImportSummary(movesAdded = 0, movesAlreadyPresent = 4), secondSummary)
-    assertEquals(
-      databaseAfterFirstImport,
-      database.getAllNodes(withDeletedOnes = true).associateBy { it.positionKey },
-    )
+    assertEquals(databaseAfterFirstImport, drainAllNodes(database).associateBy { it.positionKey })
   }
 
   @Test
@@ -81,7 +78,7 @@ class TestPgnImporter {
     assertFailsWith<PgnImportException> { importer.import(games) }
 
     // Assert
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
     assertNull(store.node(PositionKey.START_POSITION))
   }
 
@@ -227,7 +224,7 @@ class TestPgnImporter {
     importer.preview(games, perspective = Player.BLACK)
 
     // Assert
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
     assertNull(store.node(PositionKey.START_POSITION))
   }
 
@@ -241,7 +238,7 @@ class TestPgnImporter {
 
     // Assert
     assertEquals(PgnImportSummary(movesAdded = 0, movesAlreadyPresent = 0), summary)
-    assertTrue(database.getAllNodes(withDeletedOnes = true).isEmpty())
+    assertTrue(drainAllNodes(database).isEmpty())
     assertNull(store.node(PositionKey.START_POSITION))
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/CountingDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/CountingDatabaseQueryManager.kt
@@ -31,9 +31,6 @@ class CountingDatabaseQueryManager(private val delegate: DatabaseQueryManager) :
     return delegate.getPosition(positionKey)
   }
 
-  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> =
-    delegate.getAllNodes(withDeletedOnes)
-
   override suspend fun getNodesPage(cursor: String?, limit: Int) =
     delegate.getNodesPage(cursor, limit)
 

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/CountingDatabaseQueryManager.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/CountingDatabaseQueryManager.kt
@@ -34,6 +34,9 @@ class CountingDatabaseQueryManager(private val delegate: DatabaseQueryManager) :
   override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> =
     delegate.getAllNodes(withDeletedOnes)
 
+  override suspend fun getNodesPage(cursor: String?, limit: Int) =
+    delegate.getNodesPage(cursor, limit)
+
   override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) =
     delegate.deletePosition(position, mode)
 

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabases.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestDatabases.kt
@@ -67,7 +67,7 @@ object TestDatabases {
   suspend fun merge(vararg databases: InMemoryDatabaseQueryManager): InMemoryDatabaseQueryManager {
     val mergedNodes = mutableMapOf<PositionKey, DataNode>()
     for (database in databases) {
-      for (node in database.getAllNodes(withDeletedOnes = true)) {
+      for (node in drainAllNodes(database)) {
         val storedNode = mergedNodes[node.positionKey]
         if (storedNode == null) {
           mergedNodes[node.positionKey] = node

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestTestDatabase.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestTestDatabase.kt
@@ -15,7 +15,7 @@ class TestTestDatabase {
   fun testViennaDatabase() = runTest {
     val viennaDb = TestDatabases.vienna()
     val viennaMoves = getVienna()
-    val nodes = viennaDb.getAllNodes(withDeletedOnes = true)
+    val nodes = drainAllNodes(viennaDb)
 
     // Check that the database has the correct number of positions
     assertEquals(
@@ -37,7 +37,7 @@ class TestTestDatabase {
   fun testLondonDatabase() = runTest {
     val londonDb = TestDatabases.london()
     val londonMoves = getLondon()
-    val nodes = londonDb.getAllNodes(withDeletedOnes = true)
+    val nodes = drainAllNodes(londonDb)
 
     // Check that the database has the correct number of positions
     assertEquals(
@@ -59,7 +59,7 @@ class TestTestDatabase {
   fun testScandinavianDatabase() = runTest {
     val scandinavianDb = TestDatabases.scandinavian()
     val scandinavianMoves = getScandinavian()
-    val nodes = scandinavianDb.getAllNodes(withDeletedOnes = true)
+    val nodes = drainAllNodes(scandinavianDb)
 
     // Check that the database has the correct number of positions
     assertEquals(
@@ -86,9 +86,9 @@ class TestTestDatabase {
     // Merge all databases
     val mergedDb = TestDatabases.merge(viennaDb, londonDb, scandinavianDb)
 
-    val viennaNodes = viennaDb.getAllNodes(withDeletedOnes = true)
-    val londonNodes = londonDb.getAllNodes(withDeletedOnes = true)
-    val scandinavianNodes = scandinavianDb.getAllNodes(withDeletedOnes = true)
+    val viennaNodes = drainAllNodes(viennaDb)
+    val londonNodes = drainAllNodes(londonDb)
+    val scandinavianNodes = drainAllNodes(scandinavianDb)
 
     // Check that the merged database contains all positions from individual databases
     val uniquePositions =
@@ -100,7 +100,7 @@ class TestTestDatabase {
 
     assertEquals(
       uniquePositions,
-      mergedDb.getAllNodes(withDeletedOnes = true).size,
+      drainAllNodes(mergedDb).size,
       "Merged database should contain all unique positions from individual databases",
     )
 

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
@@ -1,6 +1,33 @@
 package proj.memorchess.axl.test_util
 
 import kotlin.time.Duration.Companion.seconds
+import proj.memorchess.axl.core.data.DataNode
+import proj.memorchess.axl.core.data.DatabaseQueryManager
+
+/** Default page size used when draining the whole store one bounded page at a time in tests. */
+private const val DRAIN_PAGE_SIZE = 256
+
+/**
+ * Drains every non deleted node out of [database] by looping the bounded [getNodesPage] read until
+ * the cursor terminates, returning them as a single list.
+ *
+ * This is test only assembly of a bounded fixture: production code never collects the whole store.
+ * It exists so tests that used to call the removed `getAllNodes` can keep asserting over the full
+ * live set while still exercising the paged read path the app uses.
+ *
+ * @param database The store to read from.
+ * @return Every live node, in position key ascending order.
+ */
+suspend fun drainAllNodes(database: DatabaseQueryManager): List<DataNode> {
+  val nodes = mutableListOf<DataNode>()
+  var cursor: String? = null
+  do {
+    val page = database.getNodesPage(cursor, DRAIN_PAGE_SIZE)
+    nodes.addAll(page.nodes)
+    cursor = page.nextCursor
+  } while (cursor != null)
+  return nodes
+}
 
 /**
  * Get button description according to string resource.

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/test_util/TestUtil.kt
@@ -12,13 +12,13 @@ private const val DRAIN_PAGE_SIZE = 256
  * the cursor terminates, returning them as a single list.
  *
  * This is test only assembly of a bounded fixture: production code never collects the whole store.
- * It exists so tests that used to call the removed `getAllNodes` can keep asserting over the full
- * live set while still exercising the paged read path the app uses.
+ * It exists so tests can keep asserting over the full live set while still exercising the bounded
+ * paged read path the app uses.
  *
  * @param database The store to read from.
  * @return Every live node, in position key ascending order.
  */
-suspend fun drainAllNodes(database: DatabaseQueryManager): List<DataNode> {
+internal suspend fun drainAllNodes(database: DatabaseQueryManager): List<DataNode> {
   val nodes = mutableListOf<DataNode>()
   var cursor: String? = null
   do {

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestSettings.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestSettings.kt
@@ -17,6 +17,7 @@ import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardStateFactory
 import proj.memorchess.axl.test_util.TEST_TIMEOUT
 import proj.memorchess.axl.test_util.TestWithKoin
+import proj.memorchess.axl.test_util.drainAllNodes
 import proj.memorchess.axl.ui.pages.SETTINGS_SECTION_LIST_TAG
 import proj.memorchess.axl.ui.pages.Settings
 
@@ -127,7 +128,7 @@ class TestSettings : TestWithKoin() {
     assertNodeWithTagExists("confirmDialog")
     assertNodeWithTagExists("confirmDialogCancelButton").performClick()
 
-    val positionsAfterCancel = database.getAllNodes(false)
+    val positionsAfterCancel = drainAllNodes(database)
     assertTrue("Database should not have been cleared after cancel") {
       positionsAfterCancel.isNotEmpty()
     }
@@ -137,6 +138,6 @@ class TestSettings : TestWithKoin() {
     assertNodeWithTagExists("confirmDialogOkButton").performClick()
 
     // Verify the database is cleared
-    waitUntilSuspending { database.getAllNodes(false).isEmpty() }
+    waitUntilSuspending { drainAllNodes(database).isEmpty() }
   }
 }

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/TestTraining.kt
@@ -23,6 +23,7 @@ import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
 import proj.memorchess.axl.test_util.TestWithKoin
+import proj.memorchess.axl.test_util.drainAllNodes
 import proj.memorchess.axl.ui.pages.Training
 
 private const val BRAVO_TEXT = "Bravo !"
@@ -128,7 +129,7 @@ class TestTraining : TestWithKoin() {
     playMove("e2", "e4")
     assertNodeWithTextExists(BRAVO_TEXT)
     waitUntilSuspending {
-      val positions = database.getAllNodes(false)
+      val positions = drainAllNodes(database)
       val now = DateUtil.now()
       positions.size == 1 &&
         positions[0].positionKey == PositionKey.START_POSITION &&
@@ -145,7 +146,7 @@ class TestTraining : TestWithKoin() {
     // the deck the "no more cards" Bravo screen appears once the wrong move is graded AGAIN.
     assertNodeWithTextExists(BRAVO_TEXT)
     waitUntilSuspending {
-      val positions = database.getAllNodes(false)
+      val positions = drainAllNodes(database)
       positions.size == 1 &&
         positions[0].positionKey == PositionKey.START_POSITION &&
         positions[0].cardState.lapses >= 1

--- a/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestNextMoveBar.kt
+++ b/composeApp/src/commonTest/kotlin/proj/memorchess/axl/ui/explore/TestNextMoveBar.kt
@@ -11,6 +11,7 @@ import proj.memorchess.axl.core.engine.ChessPiece
 import proj.memorchess.axl.core.engine.PieceKind
 import proj.memorchess.axl.core.engine.Player
 import proj.memorchess.axl.test_util.TestWithKoin
+import proj.memorchess.axl.test_util.drainAllNodes
 import proj.memorchess.axl.ui.assertNextMoveExist
 import proj.memorchess.axl.ui.assertPieceMoved
 import proj.memorchess.axl.ui.clickOnBack
@@ -31,7 +32,7 @@ class TestNextMoveBar : TestWithKoin() {
     playMove("e2", "e4")
     assertPieceMoved("e2", "e4", ChessPiece(PieceKind.PAWN, Player.WHITE))
     clickOnSave()
-    waitUntilSuspending { database.getAllNodes(false).size == 2 }
+    waitUntilSuspending { drainAllNodes(database).size == 2 }
   }
 
   private fun runTestFromSetup(block: ComposeUiTest.() -> Unit) = runComposeUiTest {

--- a/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestRoomSchedulingQueries.kt
+++ b/composeApp/src/jvmTest/kotlin/proj/memorchess/axl/core/data/TestRoomSchedulingQueries.kt
@@ -1,6 +1,7 @@
 package proj.memorchess.axl.core.data
 
 import androidx.room.Room
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.io.File
 import java.util.UUID
@@ -11,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import proj.memorchess.axl.core.graph.PreviousAndNextMoves
 import proj.memorchess.axl.core.scheduling.CardPhase
 import proj.memorchess.axl.core.scheduling.CardState
+import proj.memorchess.axl.core.scheduling.CardStateFactory
 
 /**
  * Room backed coverage of the bounded scheduling query surface. Mirrors the predicate, ordering and
@@ -190,6 +192,110 @@ class TestRoomSchedulingQueries {
   @Test
   fun getSchedulingCounts_emptyStoreIsAllZero() = runTest {
     manager.getSchedulingCounts(dayStart, dayEnd) shouldBe SchedulingCounts(0, 0, 0, 0, 0)
+  }
+
+  // --- getNodesPage -------------------------------------------------------------------------
+
+  /** Drains the whole store one page of [limit] at a time, returning the visited keys in order. */
+  private suspend fun pageAllKeys(limit: Int): List<PositionKey> {
+    val visited = mutableListOf<PositionKey>()
+    var cursor: String? = null
+    while (true) {
+      val page = manager.getNodesPage(cursor, limit)
+      visited += page.nodes.map { it.positionKey }
+      cursor = page.nextCursor ?: break
+    }
+    return visited
+  }
+
+  /** Inserts [count] synthetic nodes whose keys sort deterministically, returns them ascending. */
+  private suspend fun seedPageable(count: Int): List<PositionKey> {
+    val keys = (0 until count).map { PositionKey("page${it.toString().padStart(3, '0')}") }
+    keys.forEach { insert(it.value, CardPhase.NEW, dueDate = Instant.fromEpochSeconds(0)) }
+    return keys.sortedBy { it.value }
+  }
+
+  @Test
+  fun getNodesPage_pagingTheWholeStoreVisitsEveryNodeExactlyOnce() = runTest {
+    val expected = seedPageable(7)
+    val visited = pageAllKeys(limit = 3)
+    visited shouldBe expected
+    visited.toSet().size shouldBe 7
+  }
+
+  @Test
+  fun getNodesPage_lastPageHasNullNextCursor() = runTest {
+    seedPageable(2)
+    val first = manager.getNodesPage(cursor = null, limit = 2)
+    first.nodes.size shouldBe 2
+    first.nextCursor shouldBe first.nodes.last().positionKey.value
+    val second = manager.getNodesPage(cursor = first.nextCursor, limit = 2)
+    second.nodes.isEmpty() shouldBe true
+    second.nextCursor shouldBe null
+  }
+
+  @Test
+  fun getNodesPage_limitLargerThanStoreReturnsEverythingWithNullCursor() = runTest {
+    val expected = seedPageable(3)
+    val page = manager.getNodesPage(cursor = null, limit = 100)
+    page.nodes.map { it.positionKey } shouldBe expected
+    page.nextCursor shouldBe null
+  }
+
+  @Test
+  fun getNodesPage_storeSizeExactMultipleOfLimitTerminatesOnEmptyPage() = runTest {
+    val expected = seedPageable(6)
+    pageAllKeys(limit = 2) shouldBe expected
+  }
+
+  @Test
+  fun getNodesPage_emptyStoreReturnsEmptyPageWithNullCursor() = runTest {
+    val page = manager.getNodesPage(cursor = null, limit = 5)
+    page.nodes.isEmpty() shouldBe true
+    page.nextCursor shouldBe null
+  }
+
+  @Test
+  fun getNodesPage_carriesEdgesLikeASingleRead() = runTest {
+    // A two move line start -e4-> mid -e5-> end with the incident edges persisted.
+    val start = PositionKey("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq")
+    val mid = PositionKey("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq")
+    val end = PositionKey("rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq")
+    val e4 = DataMove(start, mid, "e4", isGood = true)
+    val e5 = DataMove(mid, end, "e5", isGood = true)
+    manager.insertNodes(
+      DataNode(start, PreviousAndNextMoves(listOf(), listOf(e4)), CardStateFactory.new()),
+      DataNode(mid, PreviousAndNextMoves(listOf(e4), listOf(e5)), CardStateFactory.new()),
+      DataNode(end, PreviousAndNextMoves(listOf(e5), listOf()), CardStateFactory.new()),
+    )
+    val byKey =
+      buildList {
+          var cursor: String? = null
+          while (true) {
+            val page = manager.getNodesPage(cursor, limit = 1)
+            addAll(page.nodes)
+            cursor = page.nextCursor ?: break
+          }
+        }
+        .associateBy { it.positionKey }
+    byKey.getValue(start).previousAndNextMoves.nextMoves.keys shouldBe setOf("e4")
+    byKey.getValue(mid).previousAndNextMoves.previousMoves.keys shouldBe setOf("e4")
+    byKey.getValue(mid).previousAndNextMoves.nextMoves.keys shouldBe setOf("e5")
+  }
+
+  @Test
+  fun getNodesPage_excludesSoftDeletedRows() = runTest {
+    seedPageable(3)
+    manager.deletePosition(PositionKey("page001"), proj.memorchess.axl.core.graph.DeleteMode.SOFT)
+    val keys = pageAllKeys(limit = 1)
+    keys.size shouldBe 2
+    (PositionKey("page001") in keys) shouldBe false
+  }
+
+  @Test
+  fun getNodesPage_rejectsNonPositiveLimit() = runTest {
+    shouldThrow<IllegalArgumentException> { manager.getNodesPage(cursor = null, limit = 0) }
+    shouldThrow<IllegalArgumentException> { manager.getNodesPage(cursor = null, limit = -1) }
   }
 
   @Test

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
@@ -110,6 +110,25 @@ interface NodeEntityDao {
    */
   @Transaction @Query("SELECT * FROM NodeEntity") suspend fun getAllNodes(): List<NodeWithMoves>
 
+  /**
+   * First bounded page of non deleted nodes ordered by position key ascending. See
+   * [DatabaseQueryManager.getNodesPage].
+   */
+  @Transaction
+  @Query("SELECT * FROM NodeEntity WHERE isDeleted IS FALSE ORDER BY positionKey ASC LIMIT :limit")
+  suspend fun getNodesPage(limit: Int): List<NodeWithMoves>
+
+  /**
+   * Bounded page of non deleted nodes whose position key is strictly greater than [cursor], ordered
+   * by position key ascending. See [DatabaseQueryManager.getNodesPage].
+   */
+  @Transaction
+  @Query(
+    "SELECT * FROM NodeEntity WHERE isDeleted IS FALSE AND positionKey > :cursor " +
+      "ORDER BY positionKey ASC LIMIT :limit"
+  )
+  suspend fun getNodesPageAfter(cursor: String, limit: Int): List<NodeWithMoves>
+
   @Query("SELECT * FROM MoveEntity WHERE isDeleted IS FALSE")
   suspend fun getAllMoves(): List<MoveEntity>
 

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NodeEntityDao.kt
@@ -104,13 +104,6 @@ interface NodeEntityDao {
   @Query("DELETE FROM MoveEntity") suspend fun eraseAllMoves()
 
   /**
-   * Retrieves all nodes with their moves from the database.
-   *
-   * @return A list of [NodeWithMoves] containing nodes and their associated moves.
-   */
-  @Transaction @Query("SELECT * FROM NodeEntity") suspend fun getAllNodes(): List<NodeWithMoves>
-
-  /**
    * First bounded page of non deleted nodes ordered by position key ascending. See
    * [DatabaseQueryManager.getNodesPage].
    */
@@ -128,11 +121,6 @@ interface NodeEntityDao {
       "ORDER BY positionKey ASC LIMIT :limit"
   )
   suspend fun getNodesPageAfter(cursor: String, limit: Int): List<NodeWithMoves>
-
-  @Query("SELECT * FROM MoveEntity WHERE isDeleted IS FALSE")
-  suspend fun getAllMoves(): List<MoveEntity>
-
-  @Query("SELECT * FROM MoveEntity") suspend fun getAllMovesWithDeletedOnes(): List<MoveEntity>
 
   @Query("SELECT MAX(updatedAt) FROM NodeEntity") suspend fun getLastNodeUpdate(): Instant?
 

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
@@ -27,6 +27,15 @@ internal class NonJsLocalDatabaseQueryManager(private val database: CustomDataba
     return database.getNodeEntityDao().getNode(positionKey.value)?.toStoredNode()
   }
 
+  override suspend fun getNodesPage(cursor: String?, limit: Int): NodesPage {
+    require(limit > 0) { "Page limit must be strictly positive, was $limit" }
+    val dao = database.getNodeEntityDao()
+    val rows = if (cursor == null) dao.getNodesPage(limit) else dao.getNodesPageAfter(cursor, limit)
+    val nodes = rows.map { it.toStoredNode() }
+    val nextCursor = if (nodes.size == limit) nodes.last().positionKey.value else null
+    return NodesPage(nodes, nextCursor)
+  }
+
   override suspend fun deletePosition(position: PositionKey, mode: DeleteMode) {
     val dao = database.getNodeEntityDao()
     when (mode) {

--- a/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
+++ b/composeApp/src/nonJsMain/kotlin/proj/memorchess/axl/core/data/NonJsLocalDatabaseQueryManager.kt
@@ -16,13 +16,6 @@ import proj.memorchess.axl.core.scheduling.CardState
 internal class NonJsLocalDatabaseQueryManager(private val database: CustomDatabase) :
   DatabaseQueryManager {
 
-  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> {
-    val allNodes = database.getNodeEntityDao().getAllNodes()
-    return (if (withDeletedOnes) allNodes else allNodes.filter { !it.node.isDeleted }).map {
-      it.toStoredNode()
-    }
-  }
-
   override suspend fun getPosition(positionKey: PositionKey): DataNode? {
     return database.getNodeEntityDao().getNode(positionKey.value)?.toStoredNode()
   }

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -7,6 +7,7 @@ import com.juul.indexeddb.Cursor
 import com.juul.indexeddb.Database
 import com.juul.indexeddb.Key
 import com.juul.indexeddb.bound
+import com.juul.indexeddb.lowerBound
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.JsAny
 import kotlin.js.JsArray
@@ -298,6 +299,46 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
         movesStore.index("destination").getAll(Key(positionKey.value.toJsString())).toList()
 
       jsNode.toDataNode(previousMoves.map { it.toDataMove() }, nextMoves.map { it.toDataMove() })
+    }
+  }
+
+  override suspend fun getNodesPage(cursor: String?, limit: Int): NodesPage {
+    require(limit > 0) { "Page limit must be strictly positive, was $limit" }
+    val database = db()
+    return database.transaction(NODES_STORE, MOVES_STORE) {
+      val nodesStore = objectStore(NODES_STORE)
+      val movesStore = objectStore(MOVES_STORE)
+      // Primary key range over positionKey: open lower bound skips the cursor itself so the page
+      // starts strictly after it, mirroring the SQL `positionKey > :cursor`. With a null cursor the
+      // whole store is in range and the cursor walks from the smallest key ascending.
+      val range = cursor?.let { lowerBound(it.toJsString(), open = true) }
+      val live = mutableListOf<JsNodeEntity>()
+      nodesStore
+        .openCursor(range, Cursor.Direction.Next)
+        .map { it.value as JsNodeEntity }
+        // Soft deleted rows are skipped in place so the page holds up to `limit` live nodes,
+        // exactly
+        // like the Room `WHERE isDeleted IS FALSE ... LIMIT :limit` query.
+        .firstOrNull { jsNode ->
+          if (!jsNode.isDeleted) {
+            live.add(jsNode)
+          }
+          live.size >= limit
+        }
+
+      val nodes = live.map { jsNode ->
+        val key = jsNode.positionKey
+        val nextMoves: List<JsMoveEntity> =
+          movesStore.index("origin").getAll(Key(key.toJsString())).toList()
+        val previousMoves: List<JsMoveEntity> =
+          movesStore.index("destination").getAll(Key(key.toJsString())).toList()
+        jsNode.toDataNode(
+          previousMoves = previousMoves.map { it.toDataMove() },
+          nextMoves = nextMoves.map { it.toDataMove() },
+        )
+      }
+      val nextCursor = if (nodes.size == limit) nodes.last().positionKey.value else null
+      NodesPage(nodes, nextCursor)
     }
   }
 

--- a/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/proj/memorchess/axl/core/data/JsLocalDataBaseQueryManager.wasmJs.kt
@@ -256,33 +256,6 @@ object JsLocalDatabaseQueryManager : DatabaseQueryManager {
     }
   }
 
-  override suspend fun getAllNodes(withDeletedOnes: Boolean): List<DataNode> {
-    val database = db()
-    return database.transaction(NODES_STORE, MOVES_STORE) {
-      val allJsNodes: List<JsNodeEntity> = objectStore(NODES_STORE).getAll().toList()
-      val allJsMoves: List<JsMoveEntity> = objectStore(MOVES_STORE).getAll().toList()
-
-      // Build lookup maps to avoid N+1 queries
-      val movesByOrigin = mutableMapOf<String, MutableList<DataMove>>()
-      val movesByDestination = mutableMapOf<String, MutableList<DataMove>>()
-      for (jsMove in allJsMoves) {
-        val move = jsMove.toDataMove()
-        movesByOrigin.getOrPut(move.origin.value) { mutableListOf() }.add(move)
-        movesByDestination.getOrPut(move.destination.value) { mutableListOf() }.add(move)
-      }
-
-      allJsNodes
-        .map { node ->
-          val key = node.positionKey
-          node.toDataNode(
-            previousMoves = movesByDestination[key] ?: emptyList(),
-            nextMoves = movesByOrigin[key] ?: emptyList(),
-          )
-        }
-        .let { nodes -> if (withDeletedOnes) nodes else nodes.filter { !it.isDeleted } }
-    }
-  }
-
   override suspend fun getPosition(positionKey: PositionKey): DataNode? {
     val database = db()
     return database.transaction(NODES_STORE, MOVES_STORE) {


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Summary

Phase 3 (final phase) of incremental loading. Removes the last unbounded multi-row read from the persistence layer.

- Added a bounded, cursor-paged read `getNodesPage(cursor, limit): NodesPage` to `DatabaseQueryManager` and implemented it consistently across all three backends (Room/nonJs, IndexedDB/wasmJs, in-memory). It is now the **only** multi-row read, bounded by `limit` plus an explicit cursor. Soft-deleted rows are excluded in every backend; ordering is position-key ascending and parity holds because the keys are ASCII.
- The Export button now streams page by page via `GraphSerializer.serializeStreaming`, so the heavy `DataNode` rows are never all held in memory at once. The serialized output is byte-identical to the previous eager serialize, asserted across page sizes 1 / 2 / N / N+5 plus the empty-store and deleted-node fixtures.
- Migrated all `commonTest` utilities off `getAllNodes` onto a test-only bounded `drainAllNodes` helper that loops `getNodesPage`.
- Deleted `getAllNodes` (and the dead `getAllMoves` / `getAllMovesWithDeletedOnes`) from the `DatabaseQueryManager` interface, all three backends, and the Room DAO. `grep -rn "getAllNodes" composeApp/src` now returns nothing.

The hard invariant holds: the app never fetches all rows into memory in a single call.

### Note on disk streaming

`serializeStreaming` bounds the DB reads to one page at a time (so the hard read invariant is fully met), but it still accumulates the final serialized text, the full edge list, and a `positionKey -> index` map before returning a single `String`, because the cross-platform `exportToFile(content: String)` contract takes a complete string. Literal incremental byte-to-disk streaming would require changing that `expect`/`actual` signature across all three platforms, which is out of scope for this phase. The heavy row objects are never all resident at once.

## Verification

- `:composeApp:jvmTest`: 446 tests, 0 failures, 0 errors.
- `:composeApp:compileKotlinJvm` and `:composeApp:compileKotlinWasmJs`: both BUILD SUCCESSFUL (wasm compiled only; karma test execution is flaky and was not run).
- `grep -rn "getAllNodes" composeApp/src`: no matches.

Completes #226. Stacked on #234.

Closes #226
