### PR TITLE
fix(deps): pin androidx-lifecycle below 2.11.0 to keep AGP on 9.0.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
-# IntelliJ IDEA 2026.1 supports AGP only up to the 9.0.x line; do not bump further
-# until the bundled Android plugin catches up
+# IntelliJ IDEA up to 2026.2 supports AGP only up to the 9.0.x line; do not bump
+# further until the bundled Android plugin catches up (IDEA-390133 tracks AGP 9.1).
+# androidx-lifecycle is also pinned below 2.11.0 for the same reason: 2.11.0 forces
+# AGP 9.1.0 and compileSdk 37 via its AAR metadata.
 agp = "9.0.1"
 android-compileSdk = "36"
 android-minSdk = "26"

--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
       "allowedVersions": "!/compat/"
     },
     {
-      "description": "IntelliJ IDEA 2026.1 supports AGP only up to the 9.0.x line",
+      "description": "IntelliJ IDEA up to 2026.2 supports AGP only up to the 9.0.x line (IDEA-390133 tracks AGP 9.1)",
       "matchDepNames": [
         "com.android.application",
         "com.android.library",
@@ -71,6 +71,11 @@
         "com.android.tools.build:gradle"
       ],
       "allowedVersions": "<9.1"
+    },
+    {
+      "description": "lifecycle 2.11.0 forces AGP 9.1.0 + compileSdk 37 via AAR metadata; pin below it until the AGP cap can be lifted",
+      "matchPackageNames": ["org.jetbrains.androidx.lifecycle:*"],
+      "allowedVersions": "<2.11.0"
     }
   ]
 }


### PR DESCRIPTION
## Options

- [ ] Force running tests
- [ ] Run benchmarks

## Summary

Renovate PR #239 fails `:androidApp:checkDebugAarMetadata` because the grouped bump pulls `androidx.lifecycle` `2.10.0` → `2.11.0`, and lifecycle 2.11.0 requires **AGP 9.1.0** and **compileSdk 37** via its AAR metadata. Our AGP is capped below 9.1 because IntelliJ (up to 2026.2) only supports the AGP 9.0.x line ([IDEA-390133](https://youtrack.jetbrains.com/issue/IDEA-390133) tracks AGP 9.1). So lifecycle 2.11.0 cannot be adopted yet.

This keeps AGP on 9.0.x and blocks the incompatible lifecycle bump:

- **renovate.json** — new rule pinning `org.jetbrains.androidx.lifecycle:*` below `2.11.0`, mirroring the existing AGP cap.
- **renovate.json + libs.versions.toml** — refreshed the AGP cap comments to reference IntelliJ 2026.2 and IDEA-390133.

No catalog version change: `androidx-lifecycle` stays at `2.10.0`.

Once merged, renovate rebuilds #239 dropping the lifecycle bump while keeping the compatible Kotlin 2.4.10 and kover 0.9.9 updates, and CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)